### PR TITLE
add: registry paths, tags, seek_keys, asset_digests

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -39,26 +39,23 @@ refgenie listr
 
 Response:
 ```console
-Querying available assets from server: http://refgenomes.databio.org/assets
-Remote genomes: hg19, hg19_cdna, hg38, hg38_cdna
+Querying available assets from server: http://refgenomes.databio.org/v2/assets
+Remote genomes: mouse_chrM2x, rCRSd
 Remote assets:
-  hg19: bismark_bt1_index; bismark_bt2_index; bowtie2_index; bwa_index; fasta; hisat2_index
-  hg19_cdna: bowtie2_index; hisat2_index; kallisto_index; salmon_index
-  hg38: bismark_bt1_index; bismark_bt2_index; bowtie2_index; bwa_index; fasta; hisat2_index
-  hg38_cdna: bowtie2_index; hisat2_index; kallisto_index; salmon_index
+        mouse_chrM2x/   bowtie2_index:default, fasta.chrom_sizes:default, fasta.fai:default, fasta:default
+               rCRSd/   bowtie2_index:default, fasta.chrom_sizes:default, fasta.chrom_sizes:test, fasta.fai:default, fasta.fai:test, fasta:default, fasta:test
 ```
 
 Next, pull one:
 
 ```console
-refgenie pull --genome hg38 --asset bowtie2_index
+refgenie pull rCRSd/bowtie2_index
 ```
 
 Response:
 ```console
-Starting pull for 'hg38/bowtie2_index'
-'hg38/bowtie2_index' archive size: 3.5GB
-Downloading URL: http://refgenomes.databio.org/asset/hg38/bowtie2/archive ...
+'rCRSd/bowtie2_index:default' archive size: 116.8KB
+Downloading URL: http://staging.refgenomes.databio.org/v2/asset/rCRSd/bowtie2_index/archive ... 
 ```
 
 See [further reading on downloading assets](pull.md).
@@ -67,7 +64,7 @@ See [further reading on downloading assets](pull.md).
 
 
 ```console
-refgenie build --genome mygenome --asset bwa_index --fasta mygenome.fa.gz
+refgenie build mygenome/bwa_index --fasta mygenome.fa.gz
 ```
 
 See [further reading on building assets](build.md).
@@ -77,7 +74,7 @@ See [further reading on building assets](build.md).
 Once you've populated your refgenie with a few assets, it's easy to get paths to them:
 
 ```console
-refgenie seek --genome mm10 --asset bowtie2_index
+refgenie seek mm10/bowtie2_index
 ```
 
 This will return the path to the particular asset of interest, regardless of your computing environment. This gives you an ultra-portable asset manager! See [further reading on retrieving asset paths](seek.md).

--- a/docs/asset_registry_paths.md
+++ b/docs/asset_registry_paths.md
@@ -1,0 +1,40 @@
+# Asset naming scheme
+
+Each asset is defined by *four namespace components*:
+ 
+1. genome name
+2. asset name 
+3. tag name
+4. seek key
+
+The execution of all `refgenie` commands will require at least the first one (genome name) to be specified, but most will also require the asset name. 
+
+
+## Asset registry paths
+
+The most convenient way to provide the this information on the command line is *asset registry path*: `genome/asset.seek_key:tag`, e.g. `hg38/fasta.fai:default`. Yes, that's a lot of typing if you want to be explicit, but `refgenie` makes usage of asset registry paths easy with a system of defaults, such that all the commands below return the same path:
+
+```console
+$ refgenie seek rCRSd/fasta
+path/to/genomes/archive/rCRSd/fasta/default/rCRSd.fa
+
+$ refgenie seek rCRSd/fasta.fasta
+path/to/genomes/archive/rCRSd/fasta/default/rCRSd.fa
+
+$ refgenie seek rCRSd/fasta.fasta:default
+path/to/genomes/archive/rCRSd/fasta/default/rCRSd.fa
+```
+
+How did it work?
+
+- **default tag** is determined by `default_tag` pointer in the config
+- **seek_key** defaults to the name of the asset
+
+## Arguments
+
+Alternatively, you can specify all of these namespace components as command line arguments:
+
+```config
+refgenie seek -g rCRSd -a fasta -t default 
+```
+

--- a/docs/build.md
+++ b/docs/build.md
@@ -2,13 +2,23 @@
 
 Once you've [installed refgenie](install.md), you can use `refgenie pull` to [download pre-built assets](download.md) without installing any additional software. However, you may need to use the `build` function for genomes or assets that are not available on the server. You can build assets for any genome for which you can provide the required inputs.
 
-Building assets is a bit more complicated than pulling them. If you want to build assets, you'll need to get the software required by the asset you want to build. You have two choices to get that software: you can either install it natively, or use a docker image (details further down this page). Once you're set up, you simply run `refgenie build`, passing it any necessary input arguments called for by the asset recipe.
+Building assets is a bit more complicated than pulling them. If you want to build assets, you'll need to get the software required by the asset you want to build. You have two choices to get that software: you can either install it natively, or use a docker image (details further down this page). This will start a pipeline that will create the requested asset and populate the genome config file for you. You can see the [example build output](build_output.md).  
+
+Once you're set up, you simply run `refgenie build`, passing it any necessary input arguments called for by the asset recipe. Each asset requires some input. For many of the built-in recipes, this is just a FASTA file. To learn what are the required inputs or other asset depedancies, add an `-r` flag to the `refgenie build` command: 
+
+```
+$ refgenie build hg38/bowtie2_index -r
+
+'hg38/bowtie2_index' build requirements: 
+- assets: fasta
+```  
+In this case you'll need to build the `fasta` asset for `hg38` genome before building `bowtie2_index`.
 
 ## What assets can refgenie build?
 
-At the moment the building functionality is under rapid development and may change in the future. While `refgenie` is totally flexible with respect to genome, it is more restricted in terms of what assets it can build. We are planning to allow users to specify their own recipes for arbitrary assets, but at the moment, `refgenie` can only build a handful of assets for which we have already created building recipes. Refgenie comes with built-in recipes to build indexes for common tools like bowtie2, hisat2, bismark, salmon, bwa, and a few others. If you type `refgenie list`, you'll get a list of all the assets you can build with refgenie. If you want to add a new asset, you'll have to work with us to provide a script that can build it, and we can incorporate it into refgenie. We expect this will get much easier in the future.
+At the moment the building functionality is under rapid development and may change in the future. While `refgenie` is totally flexible with respect to genome, it is more restricted in terms of what assets it can build. We are planning to allow users to specify their own recipes for arbitrary assets, but at the moment, `refgenie` can only build a handful of assets for which we have already created building recipes. Refgenie comes with built-in recipes to build indexes for common tools like bowtie2, hisat2, bismark, salmon, bwa, and a few others. If you type `refgenie list`, you'll get a list of all the assets you can build with refgenie. If you want to add a new asset, you'll have to work with us to provide a script that can build it, and we can incorporate it into `refgenie`. We expect this will get much easier in the future.
 
-Each asset requires some input. For many of the built-in recipes, this is just a FASTA file. Below, we go through the assets you can build and how to build them.
+Below, we go through the assets you can build and how to build them
 
 ## Examples for top-level assets you can build
 
@@ -25,8 +35,8 @@ Some examples are:
 
 ```
 export REFGENIE="test.yaml"
-refgenie build -g test -a fasta --fasta rCRS.fa.gz
-refgenie seek -g test -a fasta
+refgenie build test/fasta --fasta rCRS.fa.gz
+refgenie seek test/fasta
 ```
 
 ### refgene_anno
@@ -41,7 +51,7 @@ Some examples:
 
 ```
 wget http://hgdownload.soe.ucsc.edu/goldenPath/hg38/database/refGene.txt.gz
-refgenie build -g hg38 -a refgene_anno --refgene refGene.txt.gz
+refgenie build hg38/refgene_anno --refgene refGene.txt.gz
 ```
 
 ### gencode_gtf
@@ -57,13 +67,13 @@ Some examples are:
 Build the asset like:
 ```
 wget ftp://ftp.ebi.ac.uk/pub/databases/gencode/Gencode_human/release_19/gencode.v19.annotation.gtf.gz
-refgenie build -g hg19 -a gencode_gtf --gtf gencode.v19.annotation.gtf.gz
+refgenie build hg19/gencode_gtf --gencode_gtf gencode.v19.annotation.gtf.gz
 ```
 
 ### ensembl_gtf
 ```
 wget ftp://ftp.ensembl.org/pub/release-97/gtf/homo_sapiens/Homo_sapiens.GRCh38.97.gtf.gz
-refgenie build -g hg38 -a ensembl_gtf --gtf Homo_sapiens.GRCh38.97.gtf.gz
+refgenie build hg38/ensembl-gtf --ensembl_gtf Homo_sapiens.GRCh38.97.gtf.gz
 ```
 Some examples are:
 
@@ -83,34 +93,34 @@ Some examples are:
 
 ```
 wget ftp://ftp.ensembl.org/pub/release-96/regulation/homo_sapiens/homo_sapiens.GRCh38.Regulatory_Build.regulatory_features.20190122.gff.gz
-refgenie build -g hg38 -a ensembl_rb --gff homo_sapiens.GRCh38.Regulatory_Build.regulatory_features.20190122.gff.gz
+refgenie build hg38/ensembl_rb --gff homo_sapiens.GRCh38.Regulatory_Build.regulatory_features.20190122.gff.gz
 ```
 
 ## Examples for derived assets you can build
 
 ### bowtie2 index
 
-The bowtie2_index asset doesn't require any input, but does require that you've already built the `fasta` asset. So, first build the fasta asset for your genome of interest, and then you just build the `bowtie2_index` asset with no other requirements:
+The `bowtie2_index` asset doesn't require any input, but does require that you've already built the `fasta` asset. So, first build the `fasta` asset for your genome of interest, and then you just build the `bowtie2_index` asset with no other requirements:
 
 ```
-refgenie build -g test -a bowtie2_index -d 
+refgenie build test/bowtie2_index -d 
 ```
 
 ### bismark indexes
 
-The bismark index assets doesn't require any input, but does require that you've already built the `fasta` asset.
+The `bismark_index` assets doesn't require any input, but does require that you've already built the `fasta` asset.
 
 ```
-refgenie build -g test -a bismark_bt2_index -d -R
+refgenie build test/bismark_bt2_index -d -R
 ```
 
 ### ensembl_gtf
 
-The ensembl_gtf asset is a copy of the ENSEMBL annotation file. You could build it like this:
+The `ensembl_gtf asset is a copy of the ENSEMBL annotation file. You could build it like this:
 
 ```
 wget ftp://ftp.ensembl.org/pub/release-97/gtf/homo_sapiens/Homo_sapiens.GRCh38.97.gtf.gz
-refgenie build -g hg38 -a ensembl_gtf --gtf Homo_sapiens.GRCh38.97.gtf.gz
+refgenie build hg38/ensembl_gtf --ensembl-gtf Homo_sapiens.GRCh38.97.gtf.gz
 ```
 
 ## Install building software natively
@@ -122,7 +132,7 @@ Refgenie expects to find in your `PATH` any tools needed for building a desired 
 If you don't want to install all the software needed to build all these assets (and I don't blame you), then you can just use docker. Each of our recipes knows about a docker image that has everything it needs. If you have docker installed, you should be able to simply run `refgenie build` with the `-d` flag. For example:
 
 ```
-refgenie build -d --genome ... --asset ...
+refgenie build -d genome/asset ...
 ```
 
 This tells refgenie to execute the building in a docker container requested by the particular asset recipe you specify. Docker will automatically pull the image it needs when you call this. If you like, you can build the docker container yourself like this:
@@ -138,3 +148,13 @@ or pull it directly from [dockerhub](https://hub.docker.com/r/databio/refgenie) 
 ```
 docker pull databio/refgenie
 ```
+
+## Versioning the assets
+
+`refgenie` supports tags to facilitate management of multiple "versions" of the same asset. Simply add a `:your_tag_name` appendix to the asset registry path in the `refgenie build` command and the created asset will be tagged:
+
+```
+refgenie build hg38/bowtie2_index:my_tag
+```
+
+You can also learn more about [tagging refgenie assets](tag.md).

--- a/docs/build_output.md
+++ b/docs/build_output.md
@@ -1,0 +1,107 @@
+# Asset build output example 
+
+Command: 
+```
+$ refgenie build -c genomes.yaml hg38/fasta --fasta hg38.fa.gz
+```
+Output:
+```
+Output to: hg38 /Users/mstolarczyk/Desktop/testing/test_genomes /Users/mstolarczyk/Desktop/testing/test_genomes/hg38
+Removed existing flag: '/Users/mstolarczyk/Desktop/testing/test_genomes/hg38/refgenie_failed.flag'
+### Pipeline run code and environment:
+
+*              Command:  `/Library/Frameworks/Python.framework/Versions/3.6/bin/refgenie build -c genomes.yaml hg38/fasta --fasta hg38.fa.gz`
+*         Compute host:  MichalsMBP
+*          Working dir:  /Users/mstolarczyk/Desktop/testing/test_genomes
+*            Outfolder:  /Users/mstolarczyk/Desktop/testing/test_genomes/hg38/
+*  Pipeline started at:   (09-17 08:42:19) elapsed: 0.0 _TIME_
+
+### Version log:
+
+*       Python version:  3.6.5
+*          Pypiper dir:  `/Library/Frameworks/Python.framework/Versions/3.6/lib/python3.6/site-packages/pypiper`
+*      Pypiper version:  0.12.0dev
+*         Pipeline dir:  `/Library/Frameworks/Python.framework/Versions/3.6/bin`
+*     Pipeline version:  None
+
+### Arguments passed to pipeline:
+
+*            `command`:  `build`
+*             `silent`:  `False`
+*          `verbosity`:  `None`
+*             `logdev`:  `False`
+*      `genome_config`:  `genomes.yaml`
+*            `recover`:  `False`
+*        `config_file`:  `/Library/Frameworks/Python.framework/Versions/3.6/lib/python3.6/site-packages/refgenie/refgenie.yaml`
+*          `new_start`:  `False`
+*             `docker`:  `False`
+*               `tags`:  `None`
+*            `volumes`:  `None`
+*          `outfolder`:  `/Users/mstolarczyk/Desktop/testing/test_genomes`
+*       `requirements`:  `False`
+*             `genome`:  `None`
+* `asset_registry_paths`:  `['hg38/fasta']`
+*              `fasta`:  `hg38.fa.gz`
+*        `ensembl_gtf`:  `None`
+*        `gencode_gtf`:  `None`
+*                `gff`:  `None`
+*            `context`:  `None`
+*            `refgene`:  `None`
+
+----------------------------------------
+
+MissingAssetError: using 'default' as the default tag
+Inputs required to build 'fasta': fasta
+Building asset 'fasta'
+Target to produce: `/Users/mstolarczyk/Desktop/testing/test_genomes/hg38/fasta/default/build_complete.flag`  
+
+> `cp hg38.fa.gz /Users/mstolarczyk/Desktop/testing/test_genomes/hg38/fasta/default/hg38.fa.gz` (38283)
+<pre>
+</pre>
+Command completed. Elapsed time: 0:00:01. Running peak memory: 0.002GB.  
+  PID: 38283;	Command: cp;	Return code: 0;	Memory used: 0.002GB
+
+
+> `gzip -d /Users/mstolarczyk/Desktop/testing/test_genomes/hg38/fasta/default/hg38.fa.gz` (38284)
+<pre>
+</pre>
+Command completed. Elapsed time: 0:00:09. Running peak memory: 0.002GB.  
+  PID: 38284;	Command: gzip;	Return code: 0;	Memory used: 0.001GB
+
+
+> `samtools faidx /Users/mstolarczyk/Desktop/testing/test_genomes/hg38/fasta/default/hg38.fa` (38285)
+<pre>
+</pre>
+Command completed. Elapsed time: 0:00:14. Running peak memory: 0.005GB.  
+  PID: 38285;	Command: samtools;	Return code: 0;	Memory used: 0.005GB
+
+
+> `cut -f 1,2 /Users/mstolarczyk/Desktop/testing/test_genomes/hg38/fasta/default/hg38.fa.fai > /Users/mstolarczyk/Desktop/testing/test_genomes/hg38/fasta/default/hg38.chrom.sizes` (38286)
+<pre>
+</pre>
+Command completed. Elapsed time: 0:00:00. Running peak memory: 0.005GB.  
+  PID: 38286;	Command: cut;	Return code: 0;	Memory used: 0.001GB
+
+
+> `touch /Users/mstolarczyk/Desktop/testing/test_genomes/hg38/fasta/default/build_complete.flag` (38288)
+<pre>
+psutil.ZombieProcess process still exists but it's a zombie (pid=38288)
+Warning: couldn't add memory use for process: 38288
+</pre>
+Command completed. Elapsed time: 0:00:00. Running peak memory: 0.005GB.  
+  PID: 38288;	Command: touch;	Return code: 0;	Memory used: 0GB
+
+
+> `cd /Users/mstolarczyk/Desktop/testing/test_genomes/hg38/fasta/default; find . -type f -exec md5sum {} \; | sort -k 2 | awk '{print $1}' | md5sum`
+Default tag for 'hg38/fasta' set to: default
+Computing initial genome digest...
+Initializing genome...
+Finished building asset 'fasta'
+
+### Pipeline completed. Epilogue
+*        Elapsed time (this run):  0:10:23
+*  Total elapsed time (all runs):  0:16:17
+*         Peak memory (this run):  0.01 GB
+*        Pipeline completed time: 2019-09-17 08:52:42
+
+```

--- a/docs/custom_assets.md
+++ b/docs/custom_assets.md
@@ -4,34 +4,28 @@ Refgenie will write the genome configuration file automatically for any assets t
 
 ## Build a custom asset
 
-The preferred option would be to script your asset building and then allow refgenie to manage it. In the next major version of refgenie, we intend to allow the `build` function to build arbitrary assets. So, all you would need to do is be able to provide a scripted recipe and you could use refgenie to build and manage those assets automatically. In the meantime, or if you have assets that you want managed but *can't* be scripted for some reason...
+The preferred option would be to script your asset building and then allow `refgenie` to manage it. In the next major version of `refgenie`, we intend to allow the `build` function to build arbitrary assets. So, all you would need to do is be able to provide a scripted recipe and you could use `refgenie` to build and manage those assets automatically. In the meantime, or if you have assets that you want managed but *can't* be scripted for some reason...
 
 ## Add custom assets
 
 You can add additional assets with the `refgenie add` command. Just provide the genome, asset, and path *relative to the genome folder*. What this means is that you can exploit the refgenie system to manage and access your own assets. For example, say you have an hg38 annotation called *manual_annotation*, which you produced by hand. You can simply put that in your genomes folder (under `hg38/annotation_folder_dir`), and then add an entry to your genome configuration file:
 
 ```console
-refgenie add -g hg38 -a manual_anno --path annotation_folder_dir
-```
-
-## Remove assets
-
-You can easily remove assets from both disk and config file with:
-
-```console
-refgenie add -g hg38 -a bowtie2_index
+refgenie add hg38/manual_anno --path annotation_folder_dir
 ```
 
 If you want to, you could also just edit the config file by hand by adding this kind of information:
-
 
 ```yaml
 genomes:
   hg38:
     assets:
       manual_anno:
-        path: annotation_folder_dir
-        description: Manual annotations from project X
+        asset_path: manual_anno
+        asset_description: Manual annotations from project X
+        seek_keys:
+          anno1: anno1.txt
+          anno2: anno2.txt
 ```
 
 Now, you can access this asset with `refgenie` the same way you do all other assets... `refgenie list` will include it, `refgenie seek -g gh38 -a manual_anno` will retrieve the path, and from within python, `RefGenConf.get_asset('hg38', 'manual_anno')` will also work. The advantage of doing this is that it lets you include *all* your genome-associated resources, including manual ones, within the same framework.

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -1,4 +1,4 @@
-# Faq
+# FAQ
 
 ## Can I use `refgenie` with my own genome resources I've already set up?
 
@@ -7,3 +7,7 @@ Yes, you can. Of course, one of refgenie's strengths is that it makes it easy to
 ## Can I add an asset to refgenie server?
 
 Not to the central server -- at least, not automatically. But what you *can* do is run your own refgenie server... Since we made the `refgenieserver` software open-source and containerized, it's simple to host your own assets either on a local or publicly accessible web server. It's also possible that if the asset you're trying to host is of broad enough appeal, we'd be willing to add it to the central server, just drop us a line. In the future we'll also have an option for you to just add a recipe to a database of recipes.
+
+## Can I maintain multiple versions of an asset?
+
+Yes, you can. In `refgenie v0.7.0` we've introduced [tagging](tag.md), to facilitate just that!

--- a/docs/genome_config.md
+++ b/docs/genome_config.md
@@ -9,32 +9,42 @@ genome_folder: /path/to/active/genomes
 genome_server: http://refgenomes.databio.org
 genome_archive: /path/to/archived/genomes
 genomes:
-  hg38:
-    genome_description: ...
-    assets:
-      bowtie2_index:
-        path: indexed_bowtie2
-        asset_description: ...
-      hisat2_index: 
-        path: indexed_hisat2
-        asset_description: ...
-  mm10:
-    genome_description: ...
-    assets:
-      bowtie2_index:
-        path: indexed_bowtie2
-  rCRS:
-    genome_description: ...
-    assets:
-      bowtie2_index:
-        path: indexed_bowtie2
-      indexed_bowtie2:
-        path: indexed_bowtie2
-      indexed_hisat2:
-        path: indexed_hisat2
-      indexed_kallisto:
-        path: indexed_kallisto
-
+    rCRSd:
+        assets:
+          fasta:
+            tags:
+              default:
+                seek_keys:
+                  fasta: rCRSd.fa
+                  fai: rCRSd.fa.fai
+                  chrom_sizes: rCRSd.chrom.sizes
+                asset_parents: []
+                asset_path: fasta
+                asset_digest: a3c46f201a3ce7831d85cf4a125aa334
+                asset_children: ['bowtie2_index:default']
+            default_tag: default
+          bowtie2_index:
+            asset_description: Genome index for bowtie, produced with bowtie-build
+            tags:
+              default:
+                asset_path: bowtie2_index
+                seek_keys:
+                  bowtie2_index: .
+                asset_digest: 0f9217d44264ae2188fcf8e469d2bb38
+                asset_parents: ['fasta:default']
+            default_tag: default
+    hg38:
+        assets:
+          gencode_gtf:
+            asset_description: GTF annotation asset which provides access to all annotated transcripts which make up an Ensembl gene set.
+            tags:
+              default:
+                asset_path: gencode_gtf
+                seek_keys:
+                  gencode_gtf: hg38.gtf.gz
+                asset_digest: 4cd4eac99cdfdeb8ff72d8f8a4a16f9f
+                asset_parents: []
+            default_tag: default
 ```
 
 ## Details of config attributes
@@ -42,23 +52,25 @@ genomes:
 - **genome_folder**: Path to parent folder refgenie-managed assets.
 - **genome_server**: URL to a refgenieserver instance (currently only 1 URL allowed).
 - **genome_archive**: (optional; used by refgenieserver) Path to folder where asset archives will be stored.
- - **genomes**: A list of genomes, each genome has a list of assets. Any relative paths in the asset `path` attributes are considered relative to the genome folder in the config file (or the file itself if not folder path is specified), with the genome name as an intervening path component, e.g. `folder/mm10/indexed_bowtie2`.
+- **genomes**: A list of genomes, each genome has a list of assets. Any relative paths in the asset `path` attributes are considered relative to the genome folder in the config file (or the file itself if not folder path is specified), with the genome name as an intervening path component, e.g. `folder/mm10/indexed_bowtie2`.
+- **tags**: A collection of tags defined for the asset
+- **default_tag**: A pointer to the tag that is currently defined as the default one
+- **asset_parents**: A list of assets that were used to build the asset in question
+- **asset_children**: A list of assets that required the asset in question for building
+- **seek_keys**: A mapping of names and paths of the specific files within an asset
+- **asset_path**: A path to the asset folder, relative to the genome config file
+- **asset_digest**: A digest of the asset directory (more precisely, of the file contents within one) used to address the asset provenance issues when the assets are pulled or built.
 
-So, for example:
+Note that for a fully operational config just `genome_folder`, `genome_server`, `genomes`, `assets`, `tags` and `seek_keys` keys are required.
 
-```yaml
-genomes:
-  hg38:                <---- genome key
-    bowtie2:           <---- asset key
-      path: blahblah   <---- relative to genome folder
-      asset_description: freeform text (currently manual)
-      asset_checksum: 12345
-      asset_size: 15MB
-      archive_size: 12MB
-```
-
-For genomes that are managed by refgenie (that is, they were built or pulled with `refgenie`), these asset attributes will be automatically populated. You can edit them and refgenie will respect your edits (unless you re-build or re-pull the asset, which will overwrite those fields). You can also add your own assets and refgenie won't touch them. For more info, see [using external assets](external_assets.md).
+For genomes that are managed by `refgenie` (that is, they were built or pulled with `refgenie`), these asset attributes will be automatically populated. You can edit them and refgenie will respect your edits (unless you re-build or re-pull the asset, which will overwrite those fields). You can also add your own assets and `refgenie` won't touch them. For more info, see [using external assets](external_assets.md).
 
 ## Genome config versions
 
+### v0.2
 Up to version `0.4.4`, refgenie used a config file version that lacked the `assets` level in the hierarchy (so, assets were listed directly under the genome). Starting with version `0.5.0`, we moved the assets down a layer to accommodate other genome-level attributes we intend to use in the future (like a description, checksums, other provenance information). Earlier refgenie config files will need to be updated. 
+
+### v0.3
+Upt to version `0.6.0`, refgenie used the config v0.2. Currently, it uses v0.3, where we introduced: seek keys, tags, asset digests, default tag pointer, asset description
+  
+ 

--- a/docs/igenomes.md
+++ b/docs/igenomes.md
@@ -1,39 +1,83 @@
 # Using refgenie with iGenomes
 
-If you're already using iGenomes, it's easy to configure refgenie to use your existing folder structure. [iGenomes](https://support.illumina.com/sequencing/sequencing_software/igenome.html) is project that provides sequences and annotation files for commonly analyzed organisms. Each iGenome is available as a compressed file that contains sequences and annotation files for a single genomic build of an organism. 
+If you're already using iGenomes, it's easy to configure `refgenie` to use your existing folder structure. [iGenomes](https://support.illumina.com/sequencing/sequencing_software/igenome.html) is project that provides sequences and annotation files for commonly analyzed organisms. Each iGenome is available as a compressed file that contains sequences and annotation files for a single genomic build of an organism. 
 
 Initialize a refgenie config file if you don't have one you want to use for your iGenomes assets:
 
-```
-export REFGENIE='genome_config.yaml'
+```console
+export REFGENIE='igenome_config.yaml'
 refgenie init -c $REFGENIE
 ```
 
-And then add individual assets you want refgenie to track with `refgenie add`:
+And then you have two options:
 
-```
-refgenie add -g GENOME -a ASSET -p RELATIVE_PATH
-```
+1. (recommended) use `import_igenome` tool that is distributed with `refgenie` via PyPi (ready to use after `refgenie` installation)
 
-So, for example, 
+It adds all the assets enclosed in the genome archive downloaded from the iGenomes website to the `refgenie` local asset inventory. The required inputs are:
+
+* `-g`: name of the genome that should be assigned to the assets,
+* `-p`: a path to the downloaded archive or a directory (unarchived archive).
+
+usage: 
 
 ```console
-wget ftp://igenome:G3nom3s4u@ussd-ftp.illumina.com/Caenorhabditis_elegans/UCSC/ce10/Caenorhabditis_elegans_UCSC_ce10.tar.gz
-tar -xf Caenorhabditis_elegans_UCSC_ce10.tar.gz
-refgenie init -c igenome_config.yaml
-refgenie add -c igenome_config.yaml -g ce10 --asset bowtie2_index --path Caenorhabditis_elegans/UCSC/ce10/Sequence/Bowtie2Index
+$ import_igenome -h
+
+usage: import_igenome [-h] -p PATH -g GENOME [-c CONFIG]
+
+Integrates every asset from the downloaded iGenomes tarball/directory with
+Refgenie asset management system
+
+optional arguments:
+  -h, --help            show this help message and exit
+  -p PATH, --path PATH  path to the desired genome tarball or directory to
+                        integrate
+  -g GENOME, --genome GENOME
+                        name to be assigned to the selected genome
+  -c CONFIG, --config CONFIG
+                        path to local genome configuration file. Optional if
+                        'REFGENIE' environment variable is set.
+```
+
+Example:
+
+```console
+$ import_igenome -g staph -p Staphylococcus_aureus_NCTC_8325_NCBI_2006-02-13.tar.gz
+
+Moved 'Staphylococcus_aureus_NCTC_8325_NCBI_2006-02-13.tar.gz' to '/Users/mstolarczyk/Desktop/testing/test_genomes/staph'
+Added assets: 
+- staph/Chromosomes
+- staph/BWAIndex
+- staph/BowtieIndex
+- staph/AbundantSequences
+- staph/Bowtie2Index
+- staph/WholeGenomeFasta
+```
+
+2. add individual assets you want `refgenie` to track with `refgenie add`:
+
+```
+refgenie add genome/asset -p RELATIVE_PATH
+```
+
+So, after downloading an archive from iGenomes website:
+
+```console
+tar -xf Staphylococcus_aureus_NCTC_8325_NCBI_2006-02-13.tar.gz
+refgenie init $REFGENIE
+refgenie add staph/bowtie2_index -p Staphylococcus_aureus_NCTC_8325/NCBI/2006-02-13/Sequence/Bowtie2Index
 ```
 
 Now we can `seek` any of those assets:
 
 ```console
-refgenie seek -c igenome_config.yaml -g ce10 --asset bowtie2_index
+refgenie seek staph/BWAIndex
 ```
 
 Or `remove` unwanted/faulty ones:
 
 ```console
-refgenie remove -g ce10 --asset bowtie2_index
+refgenie remove staph/BWAIndex
 ```
 
 This way you can configure refgenie to use your iGenomes assets, so you can wean yourself off of the iGenomes hard structure and transition to the refgenie-managed path system.

--- a/docs/install.md
+++ b/docs/install.md
@@ -42,7 +42,7 @@ refgenie listr
 Next you need to populate your genome folder with a few assets. You can either `pull` existing assets or `build` your own. Refgenie will manage them the same way. As an example, let's pull a bowtie2 index for a small genome, the human mitochondrial genome (it's called `rCRSd`, the "Revised Cambridge Reference Sequence" on our server).
 
 ```console
-refgenie pull -g rCRSd -a bowtie2_index
+refgenie pull rCRSd/bowtie2_index
 ```
 
 You can also read more about [building refgenie assets](build.md).
@@ -52,13 +52,13 @@ You can also read more about [building refgenie assets](build.md).
 Use the `seek` command to get paths to local assets you have already built or pulled. For example, the one we just pulled:
 
 ```console
-refgenie seek -g rCRSd -a bowtie2_index
+refgenie seek rCRSd/bowtie2_index
 ```
 
 Or, more generally:
 
 ```console
-refgenie seek -g GENOME -a ASSET
+refgenie seek GENOME/ASSET
 ```
 
 That's it! Explore the HOW-TO guides in the navigation bar for further details about what you can do with these functions.

--- a/docs/pull.md
+++ b/docs/pull.md
@@ -13,18 +13,18 @@ refgenie listr
 The `pull` *downloads* the specific asset of your choice:
 
 ```console
-refgenie pull -g GENOME -a ASSET
+refgenie pull GENOME/ASSET
 ```
 Where `GENOME` refers to a genome key (*e.g.* hg38) and `ASSET` refers to one or more specific asset keys (*e.g.* bowtie2_index). For example:
 
 ```console
-refgenie pull -g hg38 -a bowtie2_index
+refgenie pull hg38/bowtie2_index
 ```
 
 You can also pull many assets at once:
 
 ```console
-refgenie pull --genome mm10 --asset bowtie2_index hisat2_index
+refgenie pull --genome mm10 bowtie2_index hisat2_index
 ```
 
 
@@ -34,7 +34,7 @@ That's it! Easy.
 
 ## Downloading manually
 
-You can also browse and download pre-built refgenie assemblies manually at [refgenomes.databio.org](http://refgenomes.databio.org).
+You can also browse and download pre-built `refgenie` assemblies manually at [refgenomes.databio.org](http://refgenomes.databio.org).
 
 <!-- 
 ## Older builds (deprecated)

--- a/docs/refgenieserver.md
+++ b/docs/refgenieserver.md
@@ -14,7 +14,7 @@ It's pretty simple: the software that runs refgenie server is [available on GitH
 docker run --rm -d -p 80:80 \
 	-v /path/to/genomes_archive:/genomes \
 	--name refgenieservercon \
-	refgenieserverim refgenieserver -c /genomes/genome_config.yaml serve 
+	refgenieserverim refgenieserver serve -c /genomes/genome_config.yaml 
 ```
 
 Mount your archived genomes folder to `/genomes` in the container, and you're essentially good to go.

--- a/docs/seek.md
+++ b/docs/seek.md
@@ -3,10 +3,10 @@
 Once you've assembled a few assets, either by downloading or by building them, you'll be able to use `refgenie seek` to retrieve the paths. It's quite simple, really -- say you've built the `bowtie2_index` and `fasta` assets for `hg38`. If you type:
 
 ```console
-refgenie seek -c CONFIG.yaml -g hg38 -a bowtie2_index
+refgenie seek -c CONFIG.yaml hg38/bowtie2_index
 ```
 
-You'll get back the absolute path on your system to the bowtie2_index asset, something like:
+You'll get back the absolute path on your system to the `bowtie2_index` asset, something like:
 
 ```console
 /path/to/genomes_folder/hg38/bowtie2_index
@@ -19,7 +19,7 @@ Because you have also built the `fasta` asset, you'll have available a few more 
 GENOME="hg38"
 
 refgenie seek -g $GENOME -a bowtie2_index
-refgenie seek -g $GENOME -a chrom_sizes
+refgenie seek -g $GENOME -a fasta.chrom_sizes
 refgenie seek -g $GENOME -a fasta
 ```
 

--- a/docs/tag.md
+++ b/docs/tag.md
@@ -1,0 +1,55 @@
+# Tagging assets
+
+## Why to tag assets?
+It is natural in a research environment to use various flavors of the reference genome related resources that may result from different versions of the software used to create them. And this is what inspired the introduction of assets tagging concept in `refgenie`.
+
+Tag can be **any text or number**, so it is well suited to contain software version information or even a concise description, like `0.4.1` or `new_build_strategy`
+
+## How to tag assets?
+
+Asset tagging was designed to be very flexible -- assets can be tagged at any point:
+
+- **tagging when assets are built:**
+
+```console
+export REFGENIE="genome_config.yaml"
+refgenie init -c $REFGENIE 
+refgenie pull hg38/fasta
+refgenie build hg38/bowtie2_index:2.3.5.1
+```
+or
+```console
+refgenie build hg38/bowtie2_index:2.3.3.1
+```
+
+- **tagging already built/pulled assets (re-tagging):**
+
+```console
+refgenie tag hg38/bowtie2_index:2.3.5.1 --tag most_recent
+```
+
+- **no tagging at all:**
+
+Importantly, you don't have to care about tags at all if you don't need to because there is a **default** representative for every asset in your assets inventory.
+
+Building without specifying a tag will tag the asset as `default`
+
+```console
+refgenie build hg38/bwa_index
+```
+
+### Default tags
+
+If you pull or build the first asset of a given kind it will become the default one, which `refgenie` will use for any actions when no tag is explicitly specified. For example the
+
+```console
+refgenie seek hg38/bowtie2_index 
+```
+
+call would return the path to the asset tagged with `most_recent` since it was the first `bowtie2_index` asset built/pulled for `hg38` genome.
+
+To retrieve the path to any other asset, you need to specify the tag:
+
+```console
+refgenie seek hg38/bowtie2_index:2.3.3.1 
+``` 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -3,7 +3,7 @@
 ## `refgenie --help`
 
 ```console
-version: 0.6.1
+version: 0.7.0
 usage: refgenie [-h] [--version] [--silent] [--verbosity V] [--logdev]
                 {init,list,listr,pull,build,seek,add,remove,getseq,tag} ...
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -3,14 +3,14 @@
 ## `refgenie --help`
 
 ```console
-version: 0.5.0
-usage: refgenie [-h] [-V] [--silent] [--verbosity V] [--logdev]
-                {init,list,listr,pull,build,seek,add,remove} ...
+version: 0.6.1
+usage: refgenie [-h] [--version] [--silent] [--verbosity V] [--logdev]
+                {init,list,listr,pull,build,seek,add,remove,getseq,tag} ...
 
 refgenie - builds and manages reference genome assemblies
 
 positional arguments:
-  {init,list,listr,pull,build,seek,add,remove}
+  {init,list,listr,pull,build,seek,add,remove,getseq,tag}
     init                Initialize a genome configuration.
     list                List available local assets.
     listr               List available remote assets.
@@ -19,11 +19,13 @@ positional arguments:
     seek                Get the path to a local asset.
     add                 Add local asset to the config file.
     remove              Remove a local asset.
+    getseq              Get sequences from a genome.
+    tag                 Assign a selected tag to an asset.
 
 optional arguments:
   -h, --help            show this help message and exit
-  -V, --version         show program's version number and exit
-  --silent              Silence logging. Overrides --verbosity.
+  --version             show program's version number and exit
+  --silent              Silence logging. Overrides verbosity.
   --verbosity V         Set logging level (1-5 or logging module level name)
   --logdev              Expand content of logging message format.
 
@@ -33,7 +35,6 @@ https://refgenie.databio.org
 ## `refgenie init --help`
 
 ```console
-version: 0.5.0
 usage: refgenie init [-h] -c GENOME_CONFIG [-s GENOME_SERVER]
 
 Initialize a genome configuration.
@@ -41,99 +42,148 @@ Initialize a genome configuration.
 optional arguments:
   -h, --help            show this help message and exit
   -c GENOME_CONFIG, --genome-config GENOME_CONFIG
-                        Path to local genome configuration file.
+                        Path to local genome configuration file. Optional if
+                        REFGENIE environment variable is set.
   -s GENOME_SERVER, --genome-server GENOME_SERVER
                         URL to use for the genome_server attribute in config
-                        file. Defaults : http://refgenomes.databio.org
+                        file. Default: http://refgenomes.databio.org
 ```
 
 ## `refgenie list --help`
 
 ```console
-version: 0.5.0
-usage: refgenie list [-h] [-c GENOME_CONFIG]
+usage: refgenie list [-h] [-c GENOME_CONFIG] [-g GENOME]
 
 List available local assets.
 
 optional arguments:
   -h, --help            show this help message and exit
   -c GENOME_CONFIG, --genome-config GENOME_CONFIG
-                        Path to local genome configuration file.
-```
-
-## `refgenie seek --help`
-
-```console
-version: 0.5.0
-usage: refgenie seek [-h] [-c GENOME_CONFIG] -g GENOME -a ASSET [ASSET ...]
-
-Get the path to a local asset.
-
-optional arguments:
-  -h, --help            show this help message and exit
-  -c GENOME_CONFIG, --genome-config GENOME_CONFIG
-                        Path to local genome configuration file.
+                        Path to local genome configuration file. Optional if
+                        REFGENIE environment variable is set.
   -g GENOME, --genome GENOME
                         Reference assembly ID, e.g. mm10
-  -a ASSET [ASSET ...], --asset ASSET [ASSET ...]
-                        Name of one or more assets (keys in genome config
-                        file)
 ```
 
 ## `refgenie listr --help`
 
 ```console
-version: 0.5.0
-usage: refgenie listr [-h] [-c GENOME_CONFIG]
+usage: refgenie listr [-h] [-c GENOME_CONFIG] [-g GENOME]
 
 List available remote assets.
 
 optional arguments:
   -h, --help            show this help message and exit
   -c GENOME_CONFIG, --genome-config GENOME_CONFIG
-                        Path to local genome configuration file.
+                        Path to local genome configuration file. Optional if
+                        REFGENIE environment variable is set.
+  -g GENOME, --genome GENOME
+                        Reference assembly ID, e.g. mm10
 ```
 
 ## `refgenie pull --help`
 
 ```console
-version: 0.5.0
-usage: refgenie pull [-h] [-c GENOME_CONFIG] -g GENOME -a ASSET [ASSET ...]
-                     [-u]
+usage: refgenie pull [-h] [-c GENOME_CONFIG] [-g GENOME] [-u]
+                     asset-registry-paths [asset-registry-paths ...]
 
 Download assets.
+
+positional arguments:
+  asset-registry-paths  One or more registry path strings that identify assets
+                        (e.g. hg38/fasta or hg38/fasta:tag)
 
 optional arguments:
   -h, --help            show this help message and exit
   -c GENOME_CONFIG, --genome-config GENOME_CONFIG
-                        Path to local genome configuration file.
+                        Path to local genome configuration file. Optional if
+                        REFGENIE environment variable is set.
   -g GENOME, --genome GENOME
                         Reference assembly ID, e.g. mm10
-  -a ASSET [ASSET ...], --asset ASSET [ASSET ...]
-                        Name of one or more assets (keys in genome config
-                        file)
   -u, --no-untar        Do not extract tarballs.
+```
+
+## `refgenie build --help`
+
+```console
+usage: refgenie build [-h] [-c GENOME_CONFIG] [-R] [-C CONFIG_FILE] [-N] [-d]
+                      [-t TAGS [TAGS ...]] [-v VOLUMES [VOLUMES ...]]
+                      [-o OUTFOLDER] [-r] [-g GENOME]
+                      asset-registry-paths [asset-registry-paths ...]
+
+Build genome assets.
+
+positional arguments:
+  asset-registry-paths  One or more registry path strings that identify assets
+                        (e.g. hg38/fasta or hg38/fasta:tag)
+
+optional arguments:
+  -h, --help            show this help message and exit
+  -c GENOME_CONFIG, --genome-config GENOME_CONFIG
+                        Path to local genome configuration file. Optional if
+                        REFGENIE environment variable is set.
+  -R, --recover         Overwrite locks to recover from previous failed run
+  -C CONFIG_FILE, --config CONFIG_FILE
+                        Pipeline configuration file (YAML). Relative paths are
+                        with respect to the pipeline script.
+  -N, --new-start       Overwrite all results to start a fresh run
+  -d, --docker          Run all commands in the refgenie docker container.
+  -t TAGS [TAGS ...], --tags TAGS [TAGS ...]
+                        Override the default tags of the parent assets (e.g.
+                        asset:tag).
+  -v VOLUMES [VOLUMES ...], --volumes VOLUMES [VOLUMES ...]
+                        If using docker, also mount these folders as volumes
+  -o OUTFOLDER, --outfolder OUTFOLDER
+                        Override the default path to genomes folder, which is
+                        the genome_folder attribute in the genome
+                        configuration file.
+  -r, --requirements    Show the build requirements for the specified asset.
+  -g GENOME, --genome GENOME
+                        Reference assembly ID, e.g. mm10
+```
+
+## `refgenie seek --help`
+
+```console
+usage: refgenie seek [-h] [-c GENOME_CONFIG] [-g GENOME]
+                     asset-registry-paths [asset-registry-paths ...]
+
+Get the path to a local asset.
+
+positional arguments:
+  asset-registry-paths  One or more registry path strings that identify assets
+                        (e.g. hg38/fasta or hg38/fasta:tag or
+                        hg38/fasta.fai:tag)
+
+optional arguments:
+  -h, --help            show this help message and exit
+  -c GENOME_CONFIG, --genome-config GENOME_CONFIG
+                        Path to local genome configuration file. Optional if
+                        REFGENIE environment variable is set.
+  -g GENOME, --genome GENOME
+                        Reference assembly ID, e.g. mm10
 ```
 
 ## `refgenie add --help`
 
 ```console
-version: 0.5.0
-usage: refgenie add [-h] [-c GENOME_CONFIG] -g GENOME -a ASSET [ASSET ...] -p
-                    PATH
+usage: refgenie add [-h] [-c GENOME_CONFIG] [-g GENOME] -p PATH
+                    asset-registry-paths [asset-registry-paths ...]
 
 Add local asset to the config file.
+
+positional arguments:
+  asset-registry-paths  One or more registry path strings that identify assets
+                        (e.g. hg38/fasta or hg38/fasta:tag)
 
 optional arguments:
   -h, --help            show this help message and exit
   -c GENOME_CONFIG, --genome-config GENOME_CONFIG
-                        Path to local genome configuration file.
+                        Path to local genome configuration file. Optional if
+                        REFGENIE environment variable is set.
   -g GENOME, --genome GENOME
                         Reference assembly ID, e.g. mm10
-  -a ASSET [ASSET ...], --asset ASSET [ASSET ...]
-                        Name of one or more assets (keys in genome config
-                        file)
-  -p PATH, --path PATH  Relative path to asset
+  -p PATH, --path PATH  Relative local path to asset
 ```
 
 ## `refgenie remove --help`
@@ -154,4 +204,45 @@ optional arguments:
   -a ASSET [ASSET ...], --asset ASSET [ASSET ...]
                         Name of one or more assets (keys in genome config
                         file)
+```
+
+## `refgenie getseq --help`
+
+```console
+usage: refgenie getseq [-h] [-c GENOME_CONFIG] -g GENOME -l LOCUS
+
+Get sequences from a genome.
+
+optional arguments:
+  -h, --help            show this help message and exit
+  -c GENOME_CONFIG, --genome-config GENOME_CONFIG
+                        Path to local genome configuration file. Optional if
+                        REFGENIE environment variable is set.
+  -g GENOME, --genome GENOME
+                        Reference assembly ID, e.g. mm10
+  -l LOCUS, --locus LOCUS
+                        Coordinates to retrieve sequence for; such has
+                        'chr1:50000-50200'.
+```
+
+## `refgenie tag --help`
+
+```console
+usage: refgenie tag [-h] [-c GENOME_CONFIG] [-g GENOME] -t TAG
+                    asset-registry-paths [asset-registry-paths ...]
+
+Assign a selected tag to an asset.
+
+positional arguments:
+  asset-registry-paths  One or more registry path strings that identify assets
+                        (e.g. hg38/fasta or hg38/fasta:tag)
+
+optional arguments:
+  -h, --help            show this help message and exit
+  -c GENOME_CONFIG, --genome-config GENOME_CONFIG
+                        Path to local genome configuration file. Optional if
+                        REFGENIE environment variable is set.
+  -g GENOME, --genome GENOME
+                        Reference assembly ID, e.g. mm10
+  -t TAG, --tag TAG     Tag to assign to an asset
 ```

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -13,6 +13,7 @@ nav:
     - Download pre-built assets: pull.md
     - Use custom genomes: build.md
     - Retrieve paths to assets: seek.md
+    - Manage multiple versions of an asset: tag.md
     - Use refgenie from python: refgenconf.md
     - Use refgenie with iGenomes: igenomes.md
     - Use custom assets: custom_assets.md

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -10,6 +10,7 @@ nav:
     - Overview: overview.md
     - Install and configure: install.md
   - How-to guides:
+    - Refer to assets: asset_registry_paths.md
     - Download pre-built assets: pull.md
     - Use custom genomes: build.md
     - Retrieve paths to assets: seek.md

--- a/refgenie/_version.py
+++ b/refgenie/_version.py
@@ -1,1 +1,1 @@
-__version__ = "0.6.1-dev"
+__version__ = "0.7.0-dev"

--- a/refgenie/add_assets_igenome.py
+++ b/refgenie/add_assets_igenome.py
@@ -7,6 +7,7 @@ Each iGenomes has the following nested directory structure:
     Annotation/ Sequence/
 """
 from .refgenie import refgenie_add
+from .exceptions import MissingGenomeConfigError
 
 from ubiquerg import untar, mkabs
 from yacman import select_config
@@ -63,7 +64,10 @@ def main():
     """ main workflow """
     parser = build_argparser()
     args, remaining_args = parser.parse_known_args()
-    rgc = refgenconf.RefGenConf(select_config(args.config, refgenconf.CFG_ENV_VARS))
+    cfg = select_config(args.config, refgenconf.CFG_ENV_VARS, check_exist=True)
+    if not cfg:
+        raise MissingGenomeConfigError(args.config)
+    rgc = refgenconf.RefGenConf(cfg)
     pths = [args.path, mkabs(args.path, rgc.genome_folder)]
     if not untar_or_copy(pths[0], os.path.join(rgc.genome_folder, args.genome)) \
             and not untar_or_copy(pths[1], os.path.join(rgc.genome_folder, args.genome)):

--- a/refgenie/add_assets_igenome.py
+++ b/refgenie/add_assets_igenome.py
@@ -30,11 +30,13 @@ def build_argparser():
     """
     parser = argparse.ArgumentParser(description='Integrates every asset from the downloaded iGenomes'
                                                  ' tarball/directory with Refgenie asset management system')
-    parser.add_argument('-p', '--path', dest="path", type=str,  help='path to the desired genome tarball to integrate',
-                        required=True)
+    parser.add_argument('-p', '--path', dest="path", type=str,
+                        help='path to the desired genome tarball or directory to integrate', required=True)
     parser.add_argument('-g', '--genome', dest="genome", type=str,  help='name to be assigned to the selected genome',
                         required=True)
-    parser.add_argument('-c', '--config', dest="config", type=str,  help='genome config', required=False)
+    parser.add_argument('-c', '--config', dest="config", type=str,
+                        help="path to local genome configuration file. Optional if '{}' environment variable is set.".
+                        format(", ".join(refgenconf.CFG_ENV_VARS)), required=False)
     return parser
 
 

--- a/refgenie/add_assets_igenome.py
+++ b/refgenie/add_assets_igenome.py
@@ -64,9 +64,9 @@ def main():
     args, remaining_args = parser.parse_known_args()
     rgc = refgenconf.RefGenConf(args.config)
     pths = [args.path, mkabs(args.path, rgc.genome_folder)]
-    if not untar_or_copy(pths[0], os.path.join(rgc.genome_folder, args.genome)):
-        if not untar_or_copy(pths[1], os.path.join(rgc.genome_folder, args.genome)):
-            raise OSError("Path '{}' does not exist. Tried: {}".format(args.path, " and ".join(pths)))
+    if not untar_or_copy(pths[0], os.path.join(rgc.genome_folder, args.genome)) \
+            and not untar_or_copy(pths[1], os.path.join(rgc.genome_folder, args.genome)):
+        raise OSError("Path '{}' does not exist. Tried: {}".format(args.path, " and ".join(pths)))
     path_components = [rgc.genome_folder] + [args.genome] + ["*"] * 3 + ["Sequence"]
     assets_paths = glob(os.path.join(*path_components))
     assert len(assets_paths) > 0, OSError("Your iGenomes directory is corrupted, more that one directory matched by {}."

--- a/refgenie/add_assets_igenome.py
+++ b/refgenie/add_assets_igenome.py
@@ -9,6 +9,7 @@ Each iGenomes has the following nested directory structure:
 from .refgenie import refgenie_add
 
 from ubiquerg import untar, mkabs
+from yacman import select_config
 
 import refgenconf
 from glob import glob
@@ -32,7 +33,7 @@ def build_argparser():
                         required=True)
     parser.add_argument('-g', '--genome', dest="genome", type=str,  help='name to be assigned to the selected genome',
                         required=True)
-    parser.add_argument('-c', '--config', dest="config", type=str,  help='genome config', required=True)
+    parser.add_argument('-c', '--config', dest="config", type=str,  help='genome config', required=False)
     return parser
 
 
@@ -62,7 +63,7 @@ def main():
     """ main workflow """
     parser = build_argparser()
     args, remaining_args = parser.parse_known_args()
-    rgc = refgenconf.RefGenConf(args.config)
+    rgc = refgenconf.RefGenConf(select_config(args.config, refgenconf.CFG_ENV_VARS))
     pths = [args.path, mkabs(args.path, rgc.genome_folder)]
     if not untar_or_copy(pths[0], os.path.join(rgc.genome_folder, args.genome)) \
             and not untar_or_copy(pths[1], os.path.join(rgc.genome_folder, args.genome)):

--- a/refgenie/add_assets_igenome.py
+++ b/refgenie/add_assets_igenome.py
@@ -16,11 +16,18 @@ from glob import glob
 import os
 import argparse
 import sys
+import tarfile
+from shutil import copytree
 
 
 def build_argparser():
-    parser = argparse.ArgumentParser(description='Integrates every asset from the downloaded iGenomes tarball/directory '
-                                                 'with Refgenie asset management system')
+    """
+    Build a parser for this tool
+
+    :return argparse.ArgumentParser: constructed parser
+    """
+    parser = argparse.ArgumentParser(description='Integrates every asset from the downloaded iGenomes'
+                                                 ' tarball/directory with Refgenie asset management system')
     parser.add_argument('-p', '--path', dest="path", type=str,  help='path to the desired genome tarball to integrate',
                         required=True)
     parser.add_argument('-g', '--genome', dest="genome", type=str,  help='name to be assigned to the selected genome',
@@ -29,31 +36,44 @@ def build_argparser():
     return parser
 
 
+def untar_or_copy(p, dest):
+    """
+    Depending on a kind of the provided path, either copy or extract it to the destination directory
+
+    :param str p: path to the directory to be copied or tarball to be extracted
+    :param str dest: where to extract file or copy dir
+    :return bool: whether the process was successful
+    """
+    if os.path.exists(p):
+        fun = untar if tarfile.is_tarfile(p) else copytree
+        fun(p, dest)
+        print("Moved '{}' to '{}'".format(p, dest))
+        return True
+    return False
+
+
 def main():
+    """ main workflow """
     parser = build_argparser()
     args, remaining_args = parser.parse_known_args()
     pths = [args.path, mkabs(args.path)]
-    for p in pths:
-        try:
-            print("Extracting '{}' to '{}'".format(p, args.genome))
-            untar(p, args.genome)
-        except FileNotFoundError:
-            continue
-        else:
-            break
-        raise OSError("Provided path does not exist, tried: {}".format(" and".join(pths)))
+    if not untar_or_copy(pths[0], args.genome):
+        if not untar_or_copy(pths[1], args.genome):
+            raise OSError("Path '{}' does not exist. Tried: {}".format(args.path, " and ".join(pths)))
     rgc = refgenconf.RefGenConf(args.config)
-    assets_paths = glob(os.path.join(*([args.genome] + ["*"] * 3 + ["Sequence"])))
-    assert len(assets_paths) == 1, OSError("your iGenomes directory is corrupted, more that one directory matched: {}".
-                                           format(os.path.join(*([args.genome] + ["*"] * 3 + ["Sequence"]))))
+    path_components = [args.genome] + ["*"] * 3 + ["Sequence"]
+    assets_paths = glob(os.path.join(*path_components))
+    assert len(assets_paths) == 1, OSError("Your iGenomes directory is corrupted, more that one directory matched by {}"
+                                           .format(os.path.join(*path_components)))
     assets_path = assets_paths[0]
-    asset_names = [dI for dI in os.listdir(assets_path) if os.path.isdir(assets_path)]
+    asset_names = [d for d in os.listdir(assets_path) if os.path.isdir(assets_path)]
+    processed = []
     for a in asset_names:
         asset_dict = {"genome": args.genome, "asset": a, "tag": None, "seek_key": None}
         asset_path = os.path.join(assets_path, a)
-        print(asset_path)
         refgenie_add(rgc, asset_dict, asset_path)
-    print("Asset added: {}/{}".format(asset_dict["genome"], asset_dict["asset"]))
+        processed.append("{}/{}".format(asset_dict["genome"], asset_dict["asset"]))
+    print("Added assets: \n- {}".format("\n- ".join(processed)))
 
 
 if __name__ == '__main__':

--- a/refgenie/add_assets_igenome.py
+++ b/refgenie/add_assets_igenome.py
@@ -69,7 +69,7 @@ def main():
         raise OSError("Path '{}' does not exist. Tried: {}".format(args.path, " and ".join(pths)))
     path_components = [rgc.genome_folder] + [args.genome] + ["*"] * 3 + ["Sequence"]
     assets_paths = glob(os.path.join(*path_components))
-    assert len(assets_paths) > 0, OSError("Your iGenomes directory is corrupted, more that one directory matched by {}."
+    assert len(assets_paths) > 0, OSError("Your iGenomes directory is corrupted, more than one directory matched by {}."
                                           "\nMatched dirs: {}".format(os.path.join(*path_components),
                                                                       ", ".join(assets_paths)))
     assets_path = assets_paths[0]

--- a/refgenie/add_assets_igenome.py
+++ b/refgenie/add_assets_igenome.py
@@ -71,8 +71,8 @@ def main():
     for a in asset_names:
         asset_dict = {"genome": args.genome, "asset": a, "tag": None, "seek_key": None}
         asset_path = os.path.join(assets_path, a)
-        refgenie_add(rgc, asset_dict, asset_path)
-        processed.append("{}/{}".format(asset_dict["genome"], asset_dict["asset"]))
+        if refgenie_add(rgc, asset_dict, asset_path):
+            processed.append("{}/{}".format(asset_dict["genome"], asset_dict["asset"]))
     print("Added assets: \n- {}".format("\n- ".join(processed)))
 
 

--- a/refgenie/add_assets_igenome.py
+++ b/refgenie/add_assets_igenome.py
@@ -1,0 +1,64 @@
+#!/usr/bin/env python
+"""
+Each iGenomes has the following nested directory structure:
+    Species/
+    Source/
+    Build/
+    Annotation/ Sequence/
+"""
+from .refgenie import refgenie_add
+
+from ubiquerg import untar, mkabs
+
+import refgenconf
+from glob import glob
+
+import os
+import argparse
+import sys
+
+
+def build_argparser():
+    parser = argparse.ArgumentParser(description='Integrates every asset from the downloaded iGenomes tarball/directory '
+                                                 'with Refgenie asset management system')
+    parser.add_argument('-p', '--path', dest="path", type=str,  help='path to the desired genome tarball to integrate',
+                        required=True)
+    parser.add_argument('-g', '--genome', dest="genome", type=str,  help='name to be assigned to the selected genome',
+                        required=True)
+    parser.add_argument('-c', '--config', dest="config", type=str,  help='genome config', required=True)
+    return parser
+
+
+def main():
+    parser = build_argparser()
+    args, remaining_args = parser.parse_known_args()
+    pths = [args.path, mkabs(args.path)]
+    for p in pths:
+        try:
+            print("Extracting '{}' to '{}'".format(p, args.genome))
+            untar(p, args.genome)
+        except FileNotFoundError:
+            continue
+        else:
+            break
+        raise OSError("Provided path does not exist, tried: {}".format(" and".join(pths)))
+    rgc = refgenconf.RefGenConf(args.config)
+    assets_paths = glob(os.path.join(*([args.genome] + ["*"] * 3 + ["Sequence"])))
+    assert len(assets_paths) == 1, OSError("your iGenomes directory is corrupted, more that one directory matched: {}".
+                                           format(os.path.join(*([args.genome] + ["*"] * 3 + ["Sequence"]))))
+    assets_path = assets_paths[0]
+    asset_names = [dI for dI in os.listdir(assets_path) if os.path.isdir(assets_path)]
+    for a in asset_names:
+        asset_dict = {"genome": args.genome, "asset": a, "tag": None, "seek_key": None}
+        asset_path = os.path.join(assets_path, a)
+        print(asset_path)
+        refgenie_add(rgc, asset_dict, asset_path)
+    print("Asset added: {}/{}".format(asset_dict["genome"], asset_dict["asset"]))
+
+
+if __name__ == '__main__':
+    try:
+        sys.exit(main())
+    except KeyboardInterrupt:
+        print("Program canceled by user!")
+        sys.exit(1)

--- a/refgenie/asset_build_packages.py
+++ b/refgenie/asset_build_packages.py
@@ -153,19 +153,19 @@ asset_build_packages = {
     },
     "gencode_gtf": {
         DESC: "GTF annotation asset which provides access to all annotated transcripts which make up an Ensembl gene set.",
-        REQ_IN: ["gencode-gtf"],
+        REQ_IN: ["gencode_gtf"],
         REQ_ASSETS: [],
         CONT: "databio/refgenie",
         ASSETS: {
             "gencode_gtf": "{genome}.gtf.gz"
         },
         CMD_LST: [
-            "cp {gtf} {asset_outfolder}/{genome}.gtf.gz"
+            "cp {gencode_gtf} {asset_outfolder}/{genome}.gtf.gz"
             ] 
     },
     "ensembl_gtf": {
         DESC: "Ensembl GTF, TSS, and gene body annotation",
-        REQ_IN: ["ensembl-gtf"],
+        REQ_IN: ["ensembl_gtf"],
         REQ_ASSETS: [],
         CONT: "databio/refgenie",
         ASSETS: {
@@ -174,7 +174,7 @@ asset_build_packages = {
             "ensembl_gene_body": "{genome}_ensembl_gene_body.bed",
         },
         CMD_LST: [
-            "cp {gtf} {asset_outfolder}/{genome}.gtf.gz",
+            "cp {ensembl_gtf} {asset_outfolder}/{genome}.gtf.gz",
             "gzip -dc {asset_outfolder}/{genome}.gtf.gz | grep 'exon_number \"1\";' | sed 's/^/chr/' | awk -v OFS='\t' '{{print $1, $4, $5, $20, $14, $7}}' | sed 's/\";//g' | sed 's/\"//g' | awk '{{if($6==\"+\"){{print $1\"\t\"$2+20\"\t\"$2+120\"\t\"$4\"\t\"$5\"\t\"$6}}else{{print $1\"\t\"$3-120\"\t\"$3-20\"\t\"$4\"\t\"$5\"\t\"$6}}}}' | LC_COLLATE=C sort -k1,1 -k2,2n -u > {asset_outfolder}/{genome}_ensembl_TSS.bed",
             "gzip -dc {asset_outfolder}/{genome}.gtf.gz | awk '$3 == \"gene\"' | sed 's/^/chr/' | awk -v OFS='\t' '{{print $1,$4,$5,$14,$6,$7}}' | sed 's/\";//g' | sed 's/\"//g' | awk '$4!=\"Metazoa_SRP\"' | awk '$4!=\"U3\"' | awk '$4!=\"7SK\"'  | awk '($3-$2)>200' | awk '{{if($6==\"+\"){{print $1\"\t\"$2+500\"\t\"$3\"\t\"$4\"\t\"$5\"\t\"$6}}else{{print $1\"\t\"$2\"\t\"$3-500\"\t\"$4\"\t\"$5\"\t\"$6}}}}' | awk '$3>$2' | LC_COLLATE=C sort -k4 -u > {asset_outfolder}/{genome}_ensembl_gene_body.bed"
             ] 

--- a/refgenie/asset_build_packages.py
+++ b/refgenie/asset_build_packages.py
@@ -45,7 +45,7 @@ asset_build_packages = {
             "bowtie2_index": "."
         },
         REQ_IN: [],
-        REQ_ASSETS: ["fasta"],
+        REQ_ASSETS: ["fasta.fasta"],
         CONT: "databio/refgenie",
         CMD_LST: [
             "bowtie2-build {fasta} {asset_outfolder}/{genome}",
@@ -57,7 +57,7 @@ asset_build_packages = {
             "bwa_index": "."
         },
         REQ_IN: [],
-        REQ_ASSETS: ["fasta"],
+        REQ_ASSETS: ["fasta.fasta"],
         CONT: "databio/refgenie",
         CMD_LST: [
             "ln -sf {fasta} {asset_outfolder}",
@@ -70,7 +70,7 @@ asset_build_packages = {
             "hisat2_index": "."
         },
         REQ_IN: [],
-        REQ_ASSETS: ["fasta"],
+        REQ_ASSETS: ["fasta.fasta"],
         CONT: "databio/refgenie",
         CMD_LST: [
             "hisat2-build {fasta} {asset_outfolder}/{genome}"
@@ -79,7 +79,7 @@ asset_build_packages = {
     "bismark_bt2_index": {
         DESC: "Genome index for Bisulfite-Seq applications, produced by bismark_genome_preparation using bowtie2",
         REQ_IN: [],
-        REQ_ASSETS: ["fasta"],
+        REQ_ASSETS: ["fasta.fasta"],
         CONT: "databio/refgenie",
         ASSETS: {
             "bismark_bt2_index": "."
@@ -92,7 +92,7 @@ asset_build_packages = {
     "bismark_bt1_index": {
         DESC: "Genome index for Bisulfite-Seq applications, produced by bismark_genome_preparation using bowtie1",
         REQ_IN: [],
-        REQ_ASSETS: ["fasta"],
+        REQ_ASSETS: ["fasta.fasta"],
         CONT: "databio/refgenie",
         ASSETS: {
             "bismark_bt1_index": "."
@@ -105,7 +105,7 @@ asset_build_packages = {
     "kallisto_index": {
         DESC: "Genome index for kallisto, produced with kallisto index",
         REQ_IN: [],
-        REQ_ASSETS: ["fasta"],
+        REQ_ASSETS: ["fasta.fasta"],
         CONT: "databio/refgenie",
         ASSETS: {
             "kallisto_index": "."
@@ -117,7 +117,7 @@ asset_build_packages = {
     "salmon_index": {
         DESC: "Transcriptome index for salmon, produced with salmon index",
         REQ_IN: [],
-        REQ_ASSETS: ["fasta"],
+        REQ_ASSETS: ["fasta.fasta"],
         CONT: "combinelab/salmon",
         ASSETS: {
             "salmon_index": "."
@@ -129,7 +129,7 @@ asset_build_packages = {
     "epilog_index": {
         DESC: "Genome index for CpG sites, produced by the epilog DNA methylation caller",
         REQ_IN: ["context"],
-        REQ_ASSETS: ["fasta"],
+        REQ_ASSETS: ["fasta.fasta"],
         CONT: "databio/refgenie",
         ASSETS: {
             "epilog_index": "."
@@ -141,7 +141,7 @@ asset_build_packages = {
     "star_index": {
         DESC: "Genome index for STAR RNA-seq aligner, produced with STAR --runMode genomeGenerate",
         REQ_IN: [],
-        REQ_ASSETS: ["fasta"],
+        REQ_ASSETS: ["fasta.fasta"],
         CONT: "databio/refgenie",
         ASSETS: {
             "star_index": "."

--- a/refgenie/asset_build_packages.py
+++ b/refgenie/asset_build_packages.py
@@ -153,7 +153,7 @@ asset_build_packages = {
     },
     "gencode_gtf": {
         DESC: "GTF annotation asset which provides access to all annotated transcripts which make up an Ensembl gene set.",
-        REQ_IN: ["gencode_gtf"],
+        REQ_IN: ["gencode-gtf"],
         REQ_ASSETS: [],
         CONT: "databio/refgenie",
         ASSETS: {
@@ -165,7 +165,7 @@ asset_build_packages = {
     },
     "ensembl_gtf": {
         DESC: "Ensembl GTF, TSS, and gene body annotation",
-        REQ_IN: ["ensembl_gtf"],
+        REQ_IN: ["ensembl-gtf"],
         REQ_ASSETS: [],
         CONT: "databio/refgenie",
         ASSETS: {

--- a/refgenie/asset_build_packages.py
+++ b/refgenie/asset_build_packages.py
@@ -153,7 +153,7 @@ asset_build_packages = {
     },
     "gencode_gtf": {
         DESC: "GTF annotation asset which provides access to all annotated transcripts which make up an Ensembl gene set.",
-        REQ_IN: ["gtf"],
+        REQ_IN: ["gencode-gtf"],
         REQ_ASSETS: [],
         CONT: "databio/refgenie",
         ASSETS: {
@@ -165,7 +165,7 @@ asset_build_packages = {
     },
     "ensembl_gtf": {
         DESC: "Ensembl GTF, TSS, and gene body annotation",
-        REQ_IN: ["gtf"],
+        REQ_IN: ["ensembl-gtf"],
         REQ_ASSETS: [],
         CONT: "databio/refgenie",
         ASSETS: {

--- a/refgenie/asset_build_packages.py
+++ b/refgenie/asset_build_packages.py
@@ -45,7 +45,7 @@ asset_build_packages = {
             "bowtie2_index": "."
         },
         REQ_IN: [],
-        REQ_ASSETS: ["fasta.fasta"],
+        REQ_ASSETS: ["fasta"],
         CONT: "databio/refgenie",
         CMD_LST: [
             "bowtie2-build {fasta} {asset_outfolder}/{genome}",
@@ -57,7 +57,7 @@ asset_build_packages = {
             "bwa_index": "."
         },
         REQ_IN: [],
-        REQ_ASSETS: ["fasta.fasta"],
+        REQ_ASSETS: ["fasta"],
         CONT: "databio/refgenie",
         CMD_LST: [
             "ln -sf {fasta} {asset_outfolder}",
@@ -70,7 +70,7 @@ asset_build_packages = {
             "hisat2_index": "."
         },
         REQ_IN: [],
-        REQ_ASSETS: ["fasta.fasta"],
+        REQ_ASSETS: ["fasta"],
         CONT: "databio/refgenie",
         CMD_LST: [
             "hisat2-build {fasta} {asset_outfolder}/{genome}"
@@ -79,7 +79,7 @@ asset_build_packages = {
     "bismark_bt2_index": {
         DESC: "Genome index for Bisulfite-Seq applications, produced by bismark_genome_preparation using bowtie2",
         REQ_IN: [],
-        REQ_ASSETS: ["fasta.fasta"],
+        REQ_ASSETS: ["fasta"],
         CONT: "databio/refgenie",
         ASSETS: {
             "bismark_bt2_index": "."
@@ -92,7 +92,7 @@ asset_build_packages = {
     "bismark_bt1_index": {
         DESC: "Genome index for Bisulfite-Seq applications, produced by bismark_genome_preparation using bowtie1",
         REQ_IN: [],
-        REQ_ASSETS: ["fasta.fasta"],
+        REQ_ASSETS: ["fasta"],
         CONT: "databio/refgenie",
         ASSETS: {
             "bismark_bt1_index": "."
@@ -105,7 +105,7 @@ asset_build_packages = {
     "kallisto_index": {
         DESC: "Genome index for kallisto, produced with kallisto index",
         REQ_IN: [],
-        REQ_ASSETS: ["fasta.fasta"],
+        REQ_ASSETS: ["fasta"],
         CONT: "databio/refgenie",
         ASSETS: {
             "kallisto_index": "."
@@ -117,7 +117,7 @@ asset_build_packages = {
     "salmon_index": {
         DESC: "Transcriptome index for salmon, produced with salmon index",
         REQ_IN: [],
-        REQ_ASSETS: ["fasta.fasta"],
+        REQ_ASSETS: ["fasta"],
         CONT: "combinelab/salmon",
         ASSETS: {
             "salmon_index": "."
@@ -129,7 +129,7 @@ asset_build_packages = {
     "epilog_index": {
         DESC: "Genome index for CpG sites, produced by the epilog DNA methylation caller",
         REQ_IN: ["context"],
-        REQ_ASSETS: ["fasta.fasta"],
+        REQ_ASSETS: ["fasta"],
         CONT: "databio/refgenie",
         ASSETS: {
             "epilog_index": "."
@@ -141,7 +141,7 @@ asset_build_packages = {
     "star_index": {
         DESC: "Genome index for STAR RNA-seq aligner, produced with STAR --runMode genomeGenerate",
         REQ_IN: [],
-        REQ_ASSETS: ["fasta.fasta"],
+        REQ_ASSETS: ["fasta"],
         CONT: "databio/refgenie",
         ASSETS: {
             "star_index": "."

--- a/refgenie/exceptions.py
+++ b/refgenie/exceptions.py
@@ -4,7 +4,7 @@ __all__ = ["RefgenieError", "MissingGenomeConfigError"]
 
 
 class RefgenieError(Exception):
-    """ Base refegnie exception type """
+    """ Base refgenie exception type """
     pass
 
 
@@ -17,9 +17,8 @@ class MissingGenomeConfigError(RefgenieError):
 
         :param str conf_file: path attempted to be used as genome config file
         """
-        msg = "You must provide a config file either as an argument " \
-              "or via an environment variable: " \
-              "{}".format(CFG_ENV_VARS)
+        msg = "You must provide a config file either as an argument or via an environment variable: {}"\
+            .format(", ".join(CFG_ENV_VARS))
         if conf_file:
             msg = "Not a file {} -- {}.".format(conf_file, msg)
         super(MissingGenomeConfigError, self).__init__(msg)

--- a/refgenie/refgenie.py
+++ b/refgenie/refgenie.py
@@ -653,6 +653,9 @@ def main():
             _LOGGER.debug("Asset '{}/{}' tagged with '{}' has been removed from the genome config".
                           format(a["genome"], a["asset"], a["tag"]))
             _LOGGER.debug("Original asset has been moved from '{}' to '{}'".format(ori_path, new_path))
+            asset = rgc[CFG_GENOMES_KEY][a["genome"]][CFG_ASSETS_KEY][a["asset"]]
+            if hasattr(asset, CFG_ASSET_DEFAULT_TAG_KEY) and asset[CFG_ASSET_DEFAULT_TAG_KEY] == a["tag"]:
+                rgc.set_default_pointer(a["genome"], a["asset"], args.tag, force=True)
         rgc.write()
 
 

--- a/refgenie/refgenie.py
+++ b/refgenie/refgenie.py
@@ -643,6 +643,8 @@ def main():
         for a in asset_list:
             a["tag"] = a["tag"] or rgc.get_default_tag(a["genome"], a["asset"], use_existing=False)
             _LOGGER.debug("Determined tag for removal: {}".format(a["tag"]))
+            if a["seek_key"] is not None:
+                raise NotImplementedError("You can't remove a specific seek_key within an asset.")
             bundle = [a["genome"], a["asset"], a["tag"]]
             try:
                 if not rgc.is_asset_complete(*bundle):

--- a/refgenie/refgenie.py
+++ b/refgenie/refgenie.py
@@ -366,8 +366,7 @@ def refgenie_build(rgc, genome, asset_list, args):
                     parent_data = prp(parent_tags[asset_build_package[REQ_ASSETS].index(req_asset)])
                     input_assets[parent_data["item"]] = rgc.get_asset(genome, parent_data["item"], parent_data["tag"],
                                                                       parent_data["subitem"])
-                    parent_assets.append("{}.{}:{}".format(parent_data["item"], parent_data["subitem"],
-                                                           parent_data["tag"]))
+                    parent_assets.append("{}:{}".format(parent_data["item"], parent_data["tag"]))
                 else:  # if no tag was requested for the req asset, use one tagged with default
                     default = prp(req_asset)
                     input_assets[default["item"]] = rgc.get_asset(genome, default["item"], None, default["subitem"])
@@ -634,6 +633,18 @@ def main():
         if len(asset_list) > 1:
             raise NotImplementedError("Can only tag 1 asset at a time")
         rgc.tag_asset(a["genome"], a["asset"], a["tag"], args.tag)
+        ori_path = rgc.get_asset(a["genome"], a["asset"], a["tag"])
+        new_path = os.path.abspath(os.path.join(ori_path, os.pardir, args.tag))
+        try:
+            os.rename(ori_path, new_path)
+        except FileNotFoundError:
+            _LOGGER.warning("Could not rename original asset tag directory '{}' to the new one '{}'".
+                            format(ori_path, new_path))
+        else:
+            rgc.remove_assets(a["genome"], a["asset"], a["tag"])
+            _LOGGER.debug("Asset '{}/{}' tagged with '{}' has been removed from the genome config".
+                          format(a["genome"], a["asset"], a["tag"]))
+            _LOGGER.debug("Original asset has been moved from '{}' to '{}'".format(ori_path, new_path))
         rgc.write()
 
 

--- a/refgenie/refgenie.py
+++ b/refgenie/refgenie.py
@@ -254,7 +254,7 @@ def refgenie_add(rgc, asset_dict, path):
             cp(abs_asset_path, tag_path)
         else:
             if not query_yes_no("Path '{}' exists? Do you want to overwrite?".format(tag_path)):
-                sys.exit(0)
+                return
             else:
                 _remove(tag_path)
                 cp(abs_asset_path, tag_path)

--- a/refgenie/refgenie.py
+++ b/refgenie/refgenie.py
@@ -44,7 +44,7 @@ GENOME_ONLY_REQUIRED = [REMOVE_CMD, GETSEQ_CMD]
 # For each asset we assume a genome is also required
 ASSET_REQUIRED = [PULL_CMD, GET_ASSET_CMD, BUILD_CMD, INSERT_CMD, TAG_CMD]
 
-BUILD_SPECIFIC_ARGS = ('fasta', 'gtf', 'gff', 'context', 'refgene')
+BUILD_SPECIFIC_ARGS = ('fasta', 'ensembl-gtf', 'gencode-gtf', 'gff', 'context', 'refgene')
 
 # This establishes the API with the server
 refgenie_server_api = {

--- a/refgenie/refgenie.py
+++ b/refgenie/refgenie.py
@@ -44,7 +44,7 @@ GENOME_ONLY_REQUIRED = [REMOVE_CMD, GETSEQ_CMD]
 # For each asset we assume a genome is also required
 ASSET_REQUIRED = [PULL_CMD, GET_ASSET_CMD, BUILD_CMD, INSERT_CMD, TAG_CMD]
 
-BUILD_SPECIFIC_ARGS = ('fasta', 'ensembl-gtf', 'gencode-gtf', 'gff', 'context', 'refgene')
+BUILD_SPECIFIC_ARGS = ('fasta', 'ensembl_gtf', 'gencode_gtf', 'gff', 'context', 'refgene')
 
 # This establishes the API with the server
 refgenie_server_api = {

--- a/refgenie/refgenie.py
+++ b/refgenie/refgenie.py
@@ -263,10 +263,11 @@ def refgenie_add(rgc, asset_dict, path):
         raise OSError("Absolute path '{}' does not exist. The provided path must be relative to: {}".
                       format(abs_asset_path, rgc.genome_folder))
     gat_bundle = [asset_dict["genome"], asset_dict["asset"], tag]
-    rgc.update_tags(*gat_bundle, {CFG_ASSET_PATH_KEY: path if os.path.isdir(abs_asset_path) else os.path.dirname(path)})
+    rgc.update_tags(*gat_bundle,
+                    data={CFG_ASSET_PATH_KEY: path if os.path.isdir(abs_asset_path) else os.path.dirname(path)})
     # seek_key points to the entire dir if not specified
     seek_key_value = os.path.basename(abs_asset_path) if asset_dict["seek_key"] is not None else "."
-    rgc.update_seek_keys(*gat_bundle, {asset_dict["seek_key"] or asset_dict["asset"]: seek_key_value})
+    rgc.update_seek_keys(*gat_bundle, data={asset_dict["seek_key"] or asset_dict["asset"]: seek_key_value})
     rgc.set_default_pointer(asset_dict["genome"], asset_dict["asset"], tag)
     # Write the updated refgenie genome configuration
     rgc.write()
@@ -381,11 +382,12 @@ def refgenie_build(rgc, genome, asset_list, args):
         else:
             _LOGGER.info("updating cfg")
             # update and write refgenie genome configuration
-            rgc.update_assets(*gat[0:2], {CFG_ASSET_DESC_KEY: build_pkg[DESC]})
-            rgc.update_tags(*gat, {CFG_ASSET_PATH_KEY: asset_key})
-            rgc.update_seek_keys(*gat, {k: v.format(**asset_vars) for k, v in build_pkg[ASSETS].items()})
+            rgc.update_assets(*gat[0:2], data={CFG_ASSET_DESC_KEY: build_pkg[DESC]})
+            rgc.update_tags(*gat, data={CFG_ASSET_PATH_KEY: asset_key})
+            rgc.update_seek_keys(*gat, data={k: v.format(**asset_vars) for k, v in build_pkg[ASSETS].items()})
             # in order to conveniently get the path to digest we update the tags metadata in two steps
-            rgc.update_tags(*gat, {CFG_ASSET_CHECKSUM_KEY: _get_asset_digest(rgc.get_asset(genome, asset_key, tag))})
+            rgc.update_tags(*gat,
+                            data={CFG_ASSET_CHECKSUM_KEY: _get_asset_digest(rgc.get_asset(genome, asset_key, tag))})
             rgc.set_default_pointer(*gat)
             rgc.write()
         return True

--- a/refgenie/refgenie.py
+++ b/refgenie/refgenie.py
@@ -253,7 +253,7 @@ def refgenie_add(rgc, asset_dict, path):
         if not os.path.exists(tag_path):
             cp(abs_asset_path, tag_path)
         else:
-            if not query_yes_no("Path '{}' exists? Do you want to overwrite?".format(tag_path)):
+            if not query_yes_no("Path '{}' exists. Do you want to overwrite?".format(tag_path)):
                 return False
             else:
                 _remove(tag_path)

--- a/refgenie/refgenie.py
+++ b/refgenie/refgenie.py
@@ -250,8 +250,14 @@ def refgenie_add(rgc, asset_dict, path):
             os.makedirs(tag_path)
         from shutil import copy2 as cp
     if os.path.exists(abs_asset_path):
-        _LOGGER.debug("Moving asset from '{}' to '{}'".format(abs_asset_path, tag_path))
-        cp(abs_asset_path, tag_path)
+        if not os.path.exists(tag_path):
+            cp(abs_asset_path, tag_path)
+        else:
+            if not query_yes_no("Path '{}' exists? Do you want to overwrite?".format(tag_path)):
+                sys.exit(0)
+            else:
+                _remove(tag_path)
+                cp(abs_asset_path, tag_path)
     else:
         raise OSError("Absolute path '{}' does not exist. The provided path must be relative to: {}".
                       format(abs_asset_path, rgc.genome_folder))
@@ -783,7 +789,6 @@ def _make_asset_build_reqs(asset):
     if asset_build_packages[asset][REQ_ASSETS]:
         reqs_list.append("- assets: {}".format(", ".join(asset_build_packages[asset][REQ_ASSETS])))
     _LOGGER.info("\n".join(reqs_list))
-
 
 
 if __name__ == '__main__':

--- a/refgenie/refgenie.py
+++ b/refgenie/refgenie.py
@@ -611,6 +611,8 @@ def main():
 
     elif args.command == REMOVE_CMD:
         for a in asset_list:
+            a["tag"] = a["tag"] or rgc.get_default_tag(a["genome"], a["asset"], use_existing=False)
+            _LOGGER.debug("Determined tag for removal: {}".format(a["tag"]))
             bundle = [a["genome"], a["asset"], a["tag"]]
             try:
                 if not rgc.is_asset_complete(*bundle):

--- a/refgenie/refgenie.py
+++ b/refgenie/refgenie.py
@@ -660,9 +660,10 @@ def main():
             raise NotImplementedError("Can only tag 1 asset at a time")
         ori_path = rgc.get_asset(a["genome"], a["asset"], a["tag"])
         new_path = os.path.abspath(os.path.join(ori_path, os.pardir, args.tag))
-        rgc.tag_asset(a["genome"], a["asset"], a["tag"], args.tag)
+        if not rgc.tag_asset(a["genome"], a["asset"], a["tag"], args.tag):  # tagging in the RefGenConf object
+            sys.exit(0)
         try:
-            os.rename(ori_path, new_path)
+            os.rename(ori_path, new_path)  # tagging in the directory
         except FileNotFoundError:
             _LOGGER.warning("Could not rename original asset tag directory '{}' to the new one '{}'".
                             format(ori_path, new_path))

--- a/refgenie/refgenie.py
+++ b/refgenie/refgenie.py
@@ -84,8 +84,8 @@ def build_argparser():
         GET_ASSET_CMD: "Get the path to a local asset.",
         INSERT_CMD: "Add local asset to the config file.",
         REMOVE_CMD: "Remove a local asset.",
-        GETSEQ_CMD: "Get sequences from a genome",
-        TAG_CMD: "Assign a selected tag to an asset"
+        GETSEQ_CMD: "Get sequences from a genome.",
+        TAG_CMD: "Assign a selected tag to an asset."
     }
 
     sps = {}

--- a/refgenie/refgenie.py
+++ b/refgenie/refgenie.py
@@ -680,7 +680,7 @@ def main():
                     _LOGGER.info("Removed an incomplete asset '{}/{}:{}'".format(*bundle))
                     return
                 else:
-                    rgc.get_asset(*bundle)
+                    rgc.get_asset(*bundle, enclosing_dir=True)
             except (KeyError, MissingAssetError, MissingGenomeError):
                 _LOGGER.info("Asset '{}/{}:{}' does not exist".format(*bundle))
                 return
@@ -697,7 +697,7 @@ def main():
         removed = []
         for a in asset_list:
             bundle = [a["genome"], a["asset"], a["tag"]]
-            asset_path = rgc.get_asset(*bundle)
+            asset_path = rgc.get_asset(*bundle, enclosing_dir=True)
             if os.path.exists(asset_path):
                 removed.append(_remove(asset_path))
                 rgc.remove_assets(*bundle).write()
@@ -724,7 +724,7 @@ def main():
     elif args.command == TAG_CMD:
         if len(asset_list) > 1:
             raise NotImplementedError("Can only tag 1 asset at a time")
-        ori_path = rgc.get_asset(a["genome"], a["asset"], a["tag"])
+        ori_path = rgc.get_asset(a["genome"], a["asset"], a["tag"], enclosing_dir=True)
         new_path = os.path.abspath(os.path.join(ori_path, os.pardir, args.tag))
         if not rgc.tag_asset(a["genome"], a["asset"], a["tag"], args.tag):  # tagging in the RefGenConf object
             sys.exit(0)

--- a/refgenie/refgenie.py
+++ b/refgenie/refgenie.py
@@ -256,11 +256,10 @@ def refgenie_add(rgc, asset_dict, path):
         raise OSError("Absolute path '{}' does not exist. The provided path must be relative to: {}".
                       format(abs_asset_path, rgc.genome_folder))
     gat_bundle = [asset_dict["genome"], asset_dict["asset"], tag]
-    rgc.update_tags(*gat_bundle,
-                    {CFG_ASSET_PATH_KEY: path if os.path.isdir(abs_asset_path) else os.path.dirname(path)})
+    rgc.update_tags(*gat_bundle, {CFG_ASSET_PATH_KEY: path if os.path.isdir(abs_asset_path) else os.path.dirname(path)})
     # seek_key points to the entire dir if not specified
-    seek_key = "." if asset_dict["seek_key"] is None else os.path.basename(abs_asset_path)
-    rgc.update_seek_keys(*gat_bundle, {asset_dict["seek_key"]:  seek_key})
+    seek_key_value = os.path.basename(abs_asset_path) if asset_dict["seek_key"] is not None else "."
+    rgc.update_seek_keys(*gat_bundle, {asset_dict["seek_key"] or asset_dict["asset"]: seek_key_value})
     rgc.set_default_pointer(asset_dict["genome"], asset_dict["asset"], tag)
     # Write the updated refgenie genome configuration
     rgc.write()

--- a/refgenie/refgenie.py
+++ b/refgenie/refgenie.py
@@ -254,7 +254,7 @@ def refgenie_add(rgc, asset_dict, path):
             cp(abs_asset_path, tag_path)
         else:
             if not query_yes_no("Path '{}' exists? Do you want to overwrite?".format(tag_path)):
-                return
+                return False
             else:
                 _remove(tag_path)
                 cp(abs_asset_path, tag_path)
@@ -269,6 +269,7 @@ def refgenie_add(rgc, asset_dict, path):
     rgc.set_default_pointer(asset_dict["genome"], asset_dict["asset"], tag)
     # Write the updated refgenie genome configuration
     rgc.write()
+    return True
 
 
 def refgenie_initg(rgc, genome, collection_checksum, content_checksums):

--- a/refgenie/refgenie.py
+++ b/refgenie/refgenie.py
@@ -353,7 +353,6 @@ def refgenie_build(rgc, genome, asset_list, args):
         if asset_key in asset_build_packages.keys():
             asset_build_package = asset_build_packages[asset_key]
             _LOGGER.debug(specific_args)
-            required_inputs = ", ".join(asset_build_package[REQ_IN])
             # handle user-requested tags for the required assets
             input_assets = {}
             parent_assets = []
@@ -374,7 +373,7 @@ def refgenie_build(rgc, genome, asset_list, args):
                     input_assets[default["item"]] = rgc.get_asset(genome, default["item"], dafault_tag, default["subitem"])
                     parent_assets.append("{}:{}".format(default["item"], dafault_tag))
             _LOGGER.debug("parents: {}".format(", ".join(parent_assets)))
-            _LOGGER.info("Inputs required to build '{}': {}".format(asset_key, required_inputs))
+            _LOGGER.info("Inputs required to build '{}': {}".format(asset_key, ", ".join(asset_build_package[REQ_IN])))
             for required_input in asset_build_package[REQ_IN]:
                 if not specific_args[required_input]:
                     raise ValueError(
@@ -630,8 +629,6 @@ def main():
                 _LOGGER.debug("Last asset from the asset package has been removed, removing enclosing dir")
                 removed.append(_remove_asset(os.path.abspath(os.path.join(asset_path, os.path.pardir))))
             else:
-                _LOGGER.info("defalut tag: {}".format(asset[CFG_ASSET_DEFAULT_TAG_KEY]))
-                _LOGGER.info("tag: {}".format(a["tag"]))
                 if hasattr(asset, CFG_ASSET_DEFAULT_TAG_KEY) and asset[CFG_ASSET_DEFAULT_TAG_KEY] == a["tag"]:
                     del rgc[CFG_GENOMES_KEY][a["genome"]][CFG_ASSETS_KEY][a["asset"]][CFG_ASSET_DEFAULT_TAG_KEY]
                     rgc.write()

--- a/refgenie/refgenie.py
+++ b/refgenie/refgenie.py
@@ -380,14 +380,13 @@ def refgenie_build(rgc, genome, asset_list, args):
             _LOGGER.error("asset '{}' build failed".format(asset_key))
             return False
         else:
-            _LOGGER.info("updating cfg")
             # update and write refgenie genome configuration
             rgc.update_assets(*gat[0:2], data={CFG_ASSET_DESC_KEY: build_pkg[DESC]})
             rgc.update_tags(*gat, data={CFG_ASSET_PATH_KEY: asset_key})
             rgc.update_seek_keys(*gat, keys={k: v.format(**asset_vars) for k, v in build_pkg[ASSETS].items()})
             # in order to conveniently get the path to digest we update the tags metadata in two steps
-            rgc.update_tags(*gat,
-                            data={CFG_ASSET_CHECKSUM_KEY: _get_asset_digest(rgc.get_asset(genome, asset_key, tag))})
+            rgc.update_tags(*gat, data={CFG_ASSET_CHECKSUM_KEY: _get_asset_digest(rgc.get_asset(
+                genome, asset_key, tag, enclosing_dir=True))})
             rgc.set_default_pointer(*gat)
             rgc.write()
         return True

--- a/refgenie/refgenie.py
+++ b/refgenie/refgenie.py
@@ -784,11 +784,32 @@ def _writeable(outdir, strict_exists=False):
 
 
 def _make_asset_build_reqs(asset):
+    """
+    Prepare requirements and inputs lists and display it
+
+    :params str asset: name of the asset
+    """
+
+    def _format_req(req):
+        """
+        Format the asset requirements.
+
+        Some of them specify seek_keys named as the assets, but we dont wanto to display that
+
+        :param str req: requirement str
+        :return:
+        """
+        reqs = req.split(".")
+        assert len(reqs) == 2, ValueError("Length of requirement '{}' after splitting is not 2. Specified requirement "
+                                          "is invalid, it should be formatted as follows: 'asset.seek_key'".format(req))
+        return reqs if reqs[1] != reqs[0] else reqs[1]
+
     reqs_list = []
     if asset_build_packages[asset][REQ_IN]:
         reqs_list.append("- arguments: {}".format(", ".join(asset_build_packages[asset][REQ_IN])))
     if asset_build_packages[asset][REQ_ASSETS]:
-        reqs_list.append("- assets: {}".format(", ".join(asset_build_packages[asset][REQ_ASSETS])))
+        reqs_list.append("- assets: {}".
+                         format(", ".join(_format_req(r) for r in asset_build_packages[asset][REQ_ASSETS])))
     _LOGGER.info("\n".join(reqs_list))
 
 

--- a/refgenie/refgenie.py
+++ b/refgenie/refgenie.py
@@ -797,7 +797,7 @@ def _make_asset_build_reqs(asset):
         Some of them specify seek_keys named as the assets, but we dont wanto to display that
 
         :param str req: requirement str
-        :return:
+        :return str: formatted requirement
         """
         reqs = req.split(".")
         assert len(reqs) == 2, ValueError("Length of requirement '{}' after splitting is not 2. Specified requirement "

--- a/refgenie/refgenie.py
+++ b/refgenie/refgenie.py
@@ -267,7 +267,7 @@ def refgenie_add(rgc, asset_dict, path):
                     data={CFG_ASSET_PATH_KEY: path if os.path.isdir(abs_asset_path) else os.path.dirname(path)})
     # seek_key points to the entire dir if not specified
     seek_key_value = os.path.basename(abs_asset_path) if asset_dict["seek_key"] is not None else "."
-    rgc.update_seek_keys(*gat_bundle, data={asset_dict["seek_key"] or asset_dict["asset"]: seek_key_value})
+    rgc.update_seek_keys(*gat_bundle, keys={asset_dict["seek_key"] or asset_dict["asset"]: seek_key_value})
     rgc.set_default_pointer(asset_dict["genome"], asset_dict["asset"], tag)
     # Write the updated refgenie genome configuration
     rgc.write()
@@ -384,7 +384,7 @@ def refgenie_build(rgc, genome, asset_list, args):
             # update and write refgenie genome configuration
             rgc.update_assets(*gat[0:2], data={CFG_ASSET_DESC_KEY: build_pkg[DESC]})
             rgc.update_tags(*gat, data={CFG_ASSET_PATH_KEY: asset_key})
-            rgc.update_seek_keys(*gat, data={k: v.format(**asset_vars) for k, v in build_pkg[ASSETS].items()})
+            rgc.update_seek_keys(*gat, keys={k: v.format(**asset_vars) for k, v in build_pkg[ASSETS].items()})
             # in order to conveniently get the path to digest we update the tags metadata in two steps
             rgc.update_tags(*gat,
                             data={CFG_ASSET_CHECKSUM_KEY: _get_asset_digest(rgc.get_asset(genome, asset_key, tag))})

--- a/refgenie/refgenie.py
+++ b/refgenie/refgenie.py
@@ -110,7 +110,7 @@ def build_argparser():
 
     sps[BUILD_CMD].add_argument(
         '-t', '--tags', nargs="+", required=False, default=None,
-        help='Override the default tags of the parent assets. Format: asset.seek_key:tag.')
+        help='Override the default tags of the parent assets (e.g. asset:tag).')
 
     sps[BUILD_CMD].add_argument(
         '-v', '--volumes', nargs="+", required=False, default=None,
@@ -373,15 +373,16 @@ def refgenie_build(rgc, genome, asset_list, args):
             selected_parent_tags = [p["item"] for p in [prp(x) for x in parent_tags]] if isinstance(parent_tags, list) \
                 else None  # if tags specified construct asset_package.asset names
             for req_asset in asset_build_package[REQ_ASSETS]:
+                req_asset_data = prp(req_asset)
                 # for each req asset see if non-default tag was requested
-                if selected_parent_tags is not None and req_asset in selected_parent_tags:
+                if selected_parent_tags is not None and req_asset_data["item"] in selected_parent_tags:
                     # if requested, add the path to the asset to the dictionary
                     parent_data = prp(parent_tags[asset_build_package[REQ_ASSETS].index(req_asset)])
                     if parent_data["tag"] is None:
                         raise ValueError("Parent asset tag was not specified. "
                                          "To use the default one, skip the -t/--tags option.")
                     input_assets[parent_data["item"]] = rgc.get_asset(genome, parent_data["item"], parent_data["tag"],
-                                                                      parent_data["subitem"])
+                                                                      req_asset_data["subitem"])
                     parent_assets.append("{}:{}".format(parent_data["item"], parent_data["tag"]))
                 else:  # if no tag was requested for the req asset, use one tagged with default
                     default = prp(req_asset)

--- a/refgenie/refgenie.py
+++ b/refgenie/refgenie.py
@@ -94,7 +94,8 @@ def build_argparser():
         # It's required for init
         sps[cmd].add_argument(
             '-c', '--genome-config', required=(cmd == INIT_CMD), dest="genome_config",
-            help="Path to local genome configuration file.")
+            help="Path to local genome configuration file. Optional if {} environment variable is set."
+                .format(", ".join(refgenconf.CFG_ENV_VARS)))
 
     sps[INIT_CMD].add_argument('-s', '--genome-server', default=DEFAULT_SERVER,
                                help="URL to use for the genome_server attribute in config file."

--- a/refgenie/refgenie.py
+++ b/refgenie/refgenie.py
@@ -110,7 +110,7 @@ def build_argparser():
 
     sps[BUILD_CMD].add_argument(
         '-t', '--tags', nargs="+", required=False, default=None,
-        help='Override the default tags of the parent assets. Format: asset:tag.')
+        help='Override the default tags of the parent assets. Format: asset.seek_key:tag.')
 
     sps[BUILD_CMD].add_argument(
         '-v', '--volumes', nargs="+", required=False, default=None,
@@ -377,6 +377,7 @@ def refgenie_build(rgc, genome, asset_list, args):
                 if selected_parent_tags is not None and req_asset in selected_parent_tags:
                     # if requested, add the path to the asset to the dictionary
                     parent_data = prp(parent_tags[asset_build_package[REQ_ASSETS].index(req_asset)])
+                    _LOGGER.info("parent data: {}".format(parent_data))
                     input_assets[parent_data["item"]] = rgc.get_asset(genome, parent_data["item"], parent_data["tag"],
                                                                       parent_data["subitem"])
                     parent_assets.append("{}:{}".format(parent_data["item"], parent_data["tag"]))
@@ -671,6 +672,8 @@ def main():
         if not rgc.tag_asset(a["genome"], a["asset"], a["tag"], args.tag):  # tagging in the RefGenConf object
             sys.exit(0)
         try:
+            if os.path.exists(new_path):
+                _remove(new_path)
             os.rename(ori_path, new_path)  # tagging in the directory
         except FileNotFoundError:
             _LOGGER.warning("Could not rename original asset tag directory '{}' to the new one '{}'".
@@ -695,7 +698,7 @@ def _remove(path):
     elif os.path.isdir(path):
         rmtree(path)
     else:
-        raise ValueError("path '{}' is neither a file nor dir.".format(path))
+        raise ValueError("path '{}' is neither a file nor a dir.".format(path))
     return path
 
 

--- a/refgenie/refgenie.py
+++ b/refgenie/refgenie.py
@@ -377,7 +377,9 @@ def refgenie_build(rgc, genome, asset_list, args):
                 if selected_parent_tags is not None and req_asset in selected_parent_tags:
                     # if requested, add the path to the asset to the dictionary
                     parent_data = prp(parent_tags[asset_build_package[REQ_ASSETS].index(req_asset)])
-                    _LOGGER.info("parent data: {}".format(parent_data))
+                    if parent_data["tag"] is None:
+                        raise ValueError("Parent asset tag was not specified. "
+                                         "To use the default one, skip the -t/--tags option.")
                     input_assets[parent_data["item"]] = rgc.get_asset(genome, parent_data["item"], parent_data["tag"],
                                                                       parent_data["subitem"])
                     parent_assets.append("{}:{}".format(parent_data["item"], parent_data["tag"]))

--- a/refgenie/refgenie.py
+++ b/refgenie/refgenie.py
@@ -174,7 +174,7 @@ def parse_registry_path(path):
         ("genome", None),
         ("asset", None),
         ("seek_key", None),
-        ("tag", "default")])
+        ("tag", None)])
 
 
 def copy_or_download_file(input_string, outfolder):
@@ -369,9 +369,10 @@ def refgenie_build(rgc, genome, asset_list, args):
                     parent_assets.append("{}:{}".format(parent_data["item"], parent_data["tag"]))
                 else:  # if no tag was requested for the req asset, use one tagged with default
                     default = prp(req_asset)
-                    input_assets[default["item"]] = rgc.get_asset(genome, default["item"], None, default["subitem"])
-                    parent_assets.append("{}.{}:{}".format(default["item"], default["subitem"], DEFAULT_TAG_NAME))
-            _LOGGER.info("parents: {}".format(", ".join(parent_assets)))
+                    dafault_tag = rgc.get_default_tag(genome, default["item"])
+                    input_assets[default["item"]] = rgc.get_asset(genome, default["item"], dafault_tag, default["subitem"])
+                    parent_assets.append("{}:{}".format(default["item"], dafault_tag))
+            _LOGGER.debug("parents: {}".format(", ".join(parent_assets)))
             _LOGGER.info("Inputs required to build '{}': {}".format(asset_key, required_inputs))
             for required_input in asset_build_package[REQ_IN]:
                 if not specific_args[required_input]:

--- a/refgenie/refgenie.py
+++ b/refgenie/refgenie.py
@@ -648,6 +648,12 @@ def main():
                 except KeyError:
                     _LOGGER.info("Last asset for genome '{}' has been removed, removing genome dir".format(a["genome"]))
                     removed.append(_remove(os.path.abspath(os.path.join(asset_path, os.path.pardir, os.path.pardir))))
+                    try:
+                        del rgc[CFG_GENOMES_KEY][a["genome"]]
+                        rgc.write()
+                    except KeyError:
+                        _LOGGER.info("Could not remove genome '{}' from the config; it does not exist".
+                                      format(a["genome"]))
             else:
                 rgc.write()
         _LOGGER.info("Successfully removed entities:\n- {}".format("\n- ".join(removed)))

--- a/refgenie/refgenie.py
+++ b/refgenie/refgenie.py
@@ -347,7 +347,7 @@ def refgenie_build(rgc, genome, asset_list, args):
 
     for a in asset_list:
         asset_key = a["asset"]
-        asset_tag = a["tag"]
+        asset_tag = a["tag"] or rgc.get_default_tag(genome, a["asset"])
 
         if asset_key in asset_build_packages.keys():
             asset_build_package = asset_build_packages[asset_key]

--- a/refgenie/refgenie.py
+++ b/refgenie/refgenie.py
@@ -576,12 +576,11 @@ def main():
                 if args.genome:
                     a["genome"] = args.genome
                 else:
-                    _LOGGER.error("Asset lacks a genome: {}".format(a["asset"]))
+                    _LOGGER.error("Asset '{}' lacks a genome".format(a["asset"]))
                     sys.exit(1)
             else:
                 if args.genome and args.genome != a["genome"]:
-                    _LOGGER.warn("Genome specified twice for asset '{}'.".format(
-                        a["name"]))
+                    _LOGGER.warn("Two different genomes specified for asset '{}'.".format(a["asset"]))
 
     else:
         if args.command in GENOME_ONLY_REQUIRED and not args.genome:

--- a/refgenie/refgenie.py
+++ b/refgenie/refgenie.py
@@ -98,8 +98,8 @@ def build_argparser():
                 .format(", ".join(refgenconf.CFG_ENV_VARS)))
 
     sps[INIT_CMD].add_argument('-s', '--genome-server', default=DEFAULT_SERVER,
-                               help="URL to use for the genome_server attribute in config file."
-                                    " Defaults : {}".format(DEFAULT_SERVER))
+                               help="URL to use for the genome_server attribute in config file. Default: {}"
+                               .format(DEFAULT_SERVER))
     sps[BUILD_CMD] = pypiper.add_pypiper_args(
         sps[BUILD_CMD], groups=None, args=["recover", "config", "new-start"])
 
@@ -129,14 +129,14 @@ def build_argparser():
                 LIST_REMOTE_CMD, LIST_LOCAL_CMD, GETSEQ_CMD, TAG_CMD]:
         # genome is not required for listing actions
         sps[cmd].add_argument(
-            "-g", "--genome", required=cmd in (GETSEQ_CMD),
+            "-g", "--genome", required=cmd in GETSEQ_CMD,
             help="Reference assembly ID, e.g. mm10")
 
     for cmd in [PULL_CMD, GET_ASSET_CMD, BUILD_CMD, INSERT_CMD, REMOVE_CMD, TAG_CMD]:
         sps[cmd].add_argument(
             "asset_registry_paths", metavar="asset-registry-paths", type=str, nargs='+',
-            help="One or more registry path strings that identify assets"
-                 " (e.g. hg38/bowtie2_index:1.0.0)")
+            help="One or more registry path strings that identify assets  (e.g. hg38/fasta or hg38/fasta:tag"
+                 + (" or hg38/fasta.fai:tag)" if cmd == GET_ASSET_CMD else ")"))
 
     sps[PULL_CMD].add_argument(
         "-u", "--no-untar", action="store_true",
@@ -593,7 +593,8 @@ def main():
                 if args.genome:
                     a["genome"] = args.genome
                 else:
-                    _LOGGER.error("Asset '{}' lacks a genome".format(a["asset"]))
+                    _LOGGER.error("Provided asset registry path ({}/{}:{}) is invalid. See help for usage reference.".
+                                  format(a["genome"], a["asset"], a["tag"]))
                     sys.exit(1)
             else:
                 if args.genome and args.genome != a["genome"]:

--- a/refgenie/refgenie.py
+++ b/refgenie/refgenie.py
@@ -373,8 +373,8 @@ def refgenie_build(rgc, genome, asset_list, args):
             input_assets = {}
             parent_assets = []
             parent_tags = args.tags
-            selected_parent_tags = ["{}.{}".format(p["item"], p["subitem"]) for p in [prp(x) for x in parent_tags]] \
-                if isinstance(parent_tags, list) else None  # if tags specified construct asset_package.asset names
+            selected_parent_tags = [p["item"] for p in [prp(x) for x in parent_tags]] if isinstance(parent_tags, list) \
+                else None  # if tags specified construct asset_package.asset names
             for req_asset in asset_build_package[REQ_ASSETS]:
                 # for each req asset see if non-default tag was requested
                 if selected_parent_tags is not None and req_asset in selected_parent_tags:

--- a/refgenie/refgenie.py
+++ b/refgenie/refgenie.py
@@ -447,13 +447,15 @@ def refgenie_build(rgc, genome, asset_list, args):
 
             # If the asset is a fasta, we first init the genome
             if asset_key == 'fasta':
-                _LOGGER.info("Initializing genome...")
+                _LOGGER.info("Computing initial genome digest...")
                 collection_checksum, content_checksums = fasta_checksum(specific_args["fasta"])
                 if genome in rgc.genomes and CFG_CHECKSUM_KEY in rgc.genomes[genome] \
                         and collection_checksum != rgc.genomes[genome][CFG_CHECKSUM_KEY]:
                     _LOGGER.info("Checksum doesn't match")
                     return False
+                _LOGGER.info("Initializing genome...")
                 refgenie_initg(rgc, genome, collection_checksum, content_checksums)
+            _LOGGER.info("Building asset '{}'".format(asset_key))    
             build_asset(genome, asset_key, asset_tag, asset_build_package, outfolder, specific_args, **input_assets)
             _LOGGER.info("Finished building asset '{}'".format(asset_key))
             # update asset relationships

--- a/setup.py
+++ b/setup.py
@@ -48,7 +48,8 @@ setup(
     license="BSD2",
     entry_points={
         "console_scripts": [
-            'refgenie = refgenie.refgenie:main'
+            'refgenie = refgenie.refgenie:main',
+            'add_igenome = refgenie.add_assets_igenome:main'
         ],
     },
     keywords="bioinformatics, sequencing, ngs",

--- a/setup.py
+++ b/setup.py
@@ -49,7 +49,7 @@ setup(
     entry_points={
         "console_scripts": [
             'refgenie = refgenie.refgenie:main',
-            'add_igenome = refgenie.add_assets_igenome:main'
+            'import_igenome = refgenie.add_assets_igenome:main'
         ],
     },
     keywords="bioinformatics, sequencing, ngs",


### PR DESCRIPTION
#92 

This provides a proof-of-concept. we would get rid of the -g and -a args, and do:

```
refgenie pull genome/asset:version
refgenie seek genome/asset:version
refgenie build genome/asset:version
```
objections?

we would retain `--genome` on any commands that don't require `--asset`, like: `list`, `getseq`.
 
disadvantage: it limits us to just one. in our current system you can specify multiple. So, perhaps we should allow both? have one establish precedence? 

In this current implementation for `pull`, you can do either; the registry path version has precedence.


Probably do this after https://github.com/databio/refgenie/pull/88
(release 0.6.1 first?)

Or just lump all these into a major new release?